### PR TITLE
Use websockets for btcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ When a new release is published, `develop` will be merged to `master` then tagge
 
 The config file can be specified with `-c` or `--config` from the command line.
 
+Otherwise, the config file is loaded from the application data directory
+(defaulted to `$HOME/.teller-skycoin`), or the local working directory.
+
+The application data directory can be changed from the command line with
+`-d` or `--dir`.
+
 The config file uses the [toml](https://github.com/toml-lang/toml) format.
 
 Teller's default config is `config.toml`. However, you should not edit this

--- a/config.toml
+++ b/config.toml
@@ -19,10 +19,9 @@ btc_addresses = "example_btc_addresses.json" # REQUIRED: path to btc addresses f
 user = "" # REQUIRED
 pass = "" # REQUIRED
 cert = "" # REQUIRED
-# websockets = false
 
 [btc_scanner]
-# scan_period = 20s
+# scan_period = "20s"
 # initial_scan_height = 492478
 # confirmations_required = 1
 
@@ -37,7 +36,7 @@ wallet = "example.wlt" # REQUIRED: path to local hot wallet file
 http_addr = "127.0.0.1:7071"
 # static_dir = "./web/build"
 # throttle_max = 60
-# throttle_duration = 60s
+# throttle_duration = "60s"
 https_addr = "" # OPTIONAL: Serve on HTTPS
 auto_tls_host = "" # OPTIONAL: Hostname to use for automatic TLS certs. Used when tls_cert, tls_key unset
 tls_cert = ""

--- a/integration-testing.md
+++ b/integration-testing.md
@@ -5,6 +5,8 @@
 * Start teller with a btcd node and skycoin node running
 * Bind an address
 * Send BTC equal to an exact multiple of the SKY/BTC rate.
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address receives the expected amount
 
 For example, if the rate is 0.0001 BTC/SKY, send 0.002 BTC and receive 2 SKY.
 
@@ -25,6 +27,8 @@ The SKY amount should be sent rounded down.
 * Start teller with a btcd node and skycoin node running
 * Bind an address
 * Send less BTC than the price of the minimum unit of SKY.
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address did not receive anything
 
 For example, if the rate is 0.001 BTC/SKY and the minimum unit is 1 SKY,
 send 0.0009 BTC and receive 0 SKY.
@@ -40,16 +44,20 @@ No SKY should be sent.
 * Confirm that both deposits were in the same block, in case the bitcoin network put them in different blocks
 * Send BTC to the address again
 * Wait for this deposit to process
+* Check that the deposits are "done" using the status check in the web client
+* Check that the SKY address receives the expected amount
 
 All three deposits should process.
 
 ## Multiple BTC deposits in one block are processed
 
 * Start teller with a btcd node and skycoin node running
-* Bind 2 addresses
+* Bind an address to two different SKY addresses each
 * Send BTC to both address, quickly enough so that they are in the same block
 * Wait for these deposits to process
 * Confirm that both deposits were in the same block, in case the bitcoin network put them in different blocks
+* Check that the deposits are "done" using the status check in the web client
+* Check that the SKY addresses receives the expected amount
 
 Both deposits should process.
 
@@ -67,6 +75,8 @@ Teller should fail to start.
 * Make a BTC deposit
 * Wait for the deposit to confirm at least 1 block
 * Restart the btcd node
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address receives the expected amount
 
 Teller should start up and begin scanning deposits.
 Then it will fail to scan more, but not exit.
@@ -87,6 +97,8 @@ Teller should fail to start
 * Wait for the deposit to be scanned
 * Wait for an error message about SKY failed to send
 * Restart the skycoin node
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address receives the expected amount
 
 Teller should start up and begin scanning deposits.
 Then it will scan the BTC deposit, and send it to the exchanger.
@@ -103,6 +115,8 @@ When the skycoin node is restarted, the send will occur.
 * Wait for the deposit to be scanned
 * Wait for an error message about SKY failed to send
 * Restart teller with a different SKY/BTC rate
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address receives the expected amount at the original rate
 
 Teller will resume sending SKY for scanned deposits when it restarts.
 When a deposit is processed, the current SKY/BTC rate is saved with the deposit.
@@ -115,8 +129,12 @@ configurable rate has been changed, that deposit receives the expected rate.
 * Bind an address
 * Make a BTC deposit
 * Wait for the deposit to be processed
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address receives the expected amount
 * Restart teller
-* Look for a message about deposit already processed
+* Look for a log message about deposit already processed
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address did not receive more coins
 
 Teller scans blocks from a fixed BTC blockchain height.  When it restarts,
 it will rescan blocks that it has already scanned.  When it detects a deposit
@@ -132,7 +150,8 @@ that has already been processed, it will not process this deposit again.
 * Make a BTC deposit
 # Look for an error when creating the transaction
 * Add sufficient coins to the skycoin wallet
-* The failed deposit should succeed now
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address receives the expected amount
 
 ### Case 2: Teller is stopped between refills
 
@@ -144,12 +163,20 @@ that has already been processed, it will not process this deposit again.
 * Stop teller
 * Add sufficient coins to the skycoin wallet
 # Start teller
-* The failed deposit should succeed now
+* Check that the deposit is "done" using the status check in the web client
+* Check that the SKY address receives the expected amount
 
 Teller will repeatedly try to create a transaction and send it until it succeeds.
 It will resume doing this between restarts.
 
 ## If the BTC address pool runs out of addresses, a clear error is provided to the client and an error is logged
+
+* Start teller with a btcd node and skycoin node running
+* Use an empty btc_addresses.json file
+* Bind an address
+* Observe the error message in the client and in the logs
+
+## If the user binds too many addresses, a clear error is provided to the client and an error is logged
 
 * Start teller with a btcd node and skycoin node running
 * Use an empty btc_addresses.json file

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -59,11 +59,10 @@ type SkyRPC struct {
 
 // BtcRPC config for btcrpc
 type BtcRPC struct {
-	Server     string `mapstructure:"server"`
-	User       string `mapstructure:"user"`
-	Pass       string `mapstructure:"pass"`
-	Cert       string `mapstructure:"cert"`
-	Websockets bool   `mapstructure:"websockets"`
+	Server string `mapstructure:"server"`
+	User   string `mapstructure:"user"`
+	Pass   string `mapstructure:"pass"`
+	Cert   string `mapstructure:"cert"`
 }
 
 // BtcScanner config for BTC scanner

--- a/src/teller/http.go
+++ b/src/teller/http.go
@@ -402,7 +402,7 @@ func BindHandler(s *HTTPServer) http.HandlerFunc {
 		btcAddr, err := s.service.BindAddress(bindReq.SkyAddr)
 		if err != nil {
 			log.WithError(err).Error("service.BindAddress failed")
-			if err != addrs.ErrDepositAddressEmpty {
+			if err != addrs.ErrDepositAddressEmpty && err != ErrMaxBoundAddresses {
 				err = errInternalServerError
 			}
 			errorResponse(ctx, w, http.StatusInternalServerError, err)

--- a/src/teller/teller.go
+++ b/src/teller/teller.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// ErrMaxBoundAddresses is returned when the maximum number of address to bind to a SKY address has been reached
-	ErrMaxBoundAddresses = errors.New("max bind reached")
+	ErrMaxBoundAddresses = errors.New("The maximum number of BTC addresses have been assigned to this SKY address")
 )
 
 // Teller provides the HTTP and teller service


### PR DESCRIPTION
The btcrpc client does not shutdown properly when using the HTTP POST
mode.  The websockets mode is preferred, according to their
documentation.  It is also much faster, and their default.