### PR TITLE
Check that RawTx array is not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ btcd includes a reference conf file: https://github.com/btcsuite/btcd/blob/maste
 
 In `~/.btcd/btcd.conf`, edit the following values:
 
+* `txindex` - set this to `1`.
 * `rpcuser` - use a long, random, secure string for this value. Set this as the value of `btc_rpc.user` in the teller conf.
 * `rpcpass` - use a long, random, secure string for this value. Set this as the value of `btc_rpc.pass` in the teller conf.
 

--- a/cmd/btcd/btcd.go
+++ b/cmd/btcd/btcd.go
@@ -306,6 +306,9 @@ func convertBlockToGetBlockVerboseResult(block *btcutil.Block) *btcjson.GetBlock
 	}
 
 	result.RawTx = txRawResults
+	for _, tx := range txRawResults {
+		result.Tx = append(result.Tx, tx.Hash)
+	}
 
 	return &result
 }

--- a/src/scanner/btc.go
+++ b/src/scanner/btc.go
@@ -19,6 +19,10 @@ import (
 
 var (
 	errQuit = errors.New("Scanner quit")
+
+	// ErrBtcdTxindexDisabled is returned if RawTx is missing from GetBlockVerboseResult,
+	// which happens if txindex is not enabled in btcd.
+	ErrBtcdTxindexDisabled = errors.New("len(block.RawTx) != len(block.Tx), make sure txindex is enabled in btcd")
 )
 
 const (
@@ -105,6 +109,12 @@ func (s *BTCScanner) Run() error {
 		if err == rpcclient.ErrClientShutdown {
 			return nil
 		}
+		return err
+	}
+
+	if len(initialBlock.RawTx) != len(initialBlock.Tx) {
+		err := ErrBtcdTxindexDisabled
+		log.WithError(err).Error("Txindex looks disabled, aborting")
 		return err
 	}
 

--- a/src/scanner/btc_test.go
+++ b/src/scanner/btc_test.go
@@ -99,6 +99,13 @@ func (dbc *dummyBtcrpcclient) GetBlockVerboseTx(hash *chainhash.Hash) (*btcjson.
 		panic("scanner should not be scanning blocks past the blockCount height")
 	}
 
+	if len(block.Tx) != len(block.RawTx) {
+		block.Tx = make([]string, 0, len(block.RawTx))
+		for _, tx := range block.RawTx {
+			block.Tx = append(block.Tx, tx.Hash)
+		}
+	}
+
 	return block, nil
 }
 

--- a/src/scanner/btc_test.go
+++ b/src/scanner/btc_test.go
@@ -99,11 +99,9 @@ func (dbc *dummyBtcrpcclient) GetBlockVerboseTx(hash *chainhash.Hash) (*btcjson.
 		panic("scanner should not be scanning blocks past the blockCount height")
 	}
 
-	if len(block.Tx) != len(block.RawTx) {
-		block.Tx = make([]string, 0, len(block.RawTx))
-		for _, tx := range block.RawTx {
-			block.Tx = append(block.Tx, tx.Hash)
-		}
+	block.Tx = make([]string, 0, len(block.RawTx))
+	for _, tx := range block.RawTx {
+		block.Tx = append(block.Tx, tx.Hash)
 	}
 
 	return block, nil

--- a/src/scanner/store.go
+++ b/src/scanner/store.go
@@ -257,7 +257,7 @@ func (s *BTCStore) ScanBlock(block *btcjson.GetBlockVerboseResult) ([]Deposit, e
 func ScanBTCBlock(block *btcjson.GetBlockVerboseResult, depositAddrs []string) ([]Deposit, error) {
 	// Assert that RawTx matches Tx
 	if len(block.RawTx) != len(block.Tx) {
-		return nil, errors.New("len(block.RawTx) != len(block.Tx). Make sure txindex is enabled in btcd")
+		return nil, ErrBtcdTxindexDisabled
 	}
 
 	addrMap := map[string]struct{}{}

--- a/src/scanner/store.go
+++ b/src/scanner/store.go
@@ -255,6 +255,11 @@ func (s *BTCStore) ScanBlock(block *btcjson.GetBlockVerboseResult) ([]Deposit, e
 
 // ScanBTCBlock scan the given block and returns the next block hash or error
 func ScanBTCBlock(block *btcjson.GetBlockVerboseResult, depositAddrs []string) ([]Deposit, error) {
+	// Assert that RawTx matches Tx
+	if len(block.RawTx) != len(block.Tx) {
+		return nil, errors.New("len(block.RawTx) != len(block.Tx). Make sure txindex is enabled in btcd.")
+	}
+
 	addrMap := map[string]struct{}{}
 	for _, a := range depositAddrs {
 		addrMap[a] = struct{}{}

--- a/src/scanner/store.go
+++ b/src/scanner/store.go
@@ -257,7 +257,7 @@ func (s *BTCStore) ScanBlock(block *btcjson.GetBlockVerboseResult) ([]Deposit, e
 func ScanBTCBlock(block *btcjson.GetBlockVerboseResult, depositAddrs []string) ([]Deposit, error) {
 	// Assert that RawTx matches Tx
 	if len(block.RawTx) != len(block.Tx) {
-		return nil, errors.New("len(block.RawTx) != len(block.Tx). Make sure txindex is enabled in btcd.")
+		return nil, errors.New("len(block.RawTx) != len(block.Tx). Make sure txindex is enabled in btcd")
 	}
 
 	addrMap := map[string]struct{}{}


### PR DESCRIPTION
If btcd's `txindex` option is not enabled, `RawTx` will be empty.  Detect this problem and warn the user with an error.