### PR TITLE
sky_exchanger.max_decimals configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Description of the config file:
 * `btc_scanner.initial_scan_height` [int]: Begin scanning from this BTC blockchain height.
 * `btc_scanner.confirmations_required` [int]: Number of confirmations required before sending skycoins for a BTC deposit.
 * `sky_exchanger.sky_btc_exchange_rate` [string]: How much SKY to send per BTC. This can be written as an integer, float, or a rational fraction.
+* `sky_exchanger.max_decimals` [int]: Number of decimal places to truncate SKY to.
 * `sky_exchanger.wallet` [string]: Filepath of the skycoin hot wallet. See [setup skycoin hot wallet](#setup-skycoin-hot-wallet).
 * `sky_exchanger.tx_confirmation_check_wait` [duration]: How often to check for a sent skycoin transaction's confirmation.
 * `web.behind_proxy` [bool]: Set true if running behind a proxy.
@@ -344,6 +345,7 @@ Response:
     "enabled": true,
     "btc_confirmations_required": 1,
     "max_bound_btc_addrs": 5,
+    "max_decimals": 0,
     "sky_btc_exchange_rate": "123.000000"
 }
 ```

--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,7 @@ cert = "" # REQUIRED
 [sky_exchanger]
 sky_btc_exchange_rate = "500" # REQUIRED: SKY/BTC exchange rate as a string, can be an int, float or a rational fraction
 wallet = "example.wlt" # REQUIRED: path to local hot wallet file
+# max_decimals = 0  # Number of decimal places to truncate SKY to
 # tx_confirmation_check_wait = "5s"
 
 [web]

--- a/src/exchange/calculate.go
+++ b/src/exchange/calculate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/shopspring/decimal"
 
-	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/util/droplet"
 
 	"github.com/skycoin/teller/src/util/mathutil"
@@ -13,10 +12,14 @@ import (
 
 // CalculateBtcSkyValue returns the amount of SKY (in droplets) to give for an
 // amount of BTC (in satoshis).
-// Rate is measured in SKY per BTC. It should be a decimal string
-func CalculateBtcSkyValue(satoshis int64, skyPerBTC string) (uint64, error) {
+// Rate is measured in SKY per BTC. It should be a decimal string.
+// MaxDecimals is the number of decimal places to truncate to.
+func CalculateBtcSkyValue(satoshis int64, skyPerBTC string, maxDecimals int) (uint64, error) {
 	if satoshis < 0 {
 		return 0, errors.New("satoshis must be greater than or equal to 0")
+	}
+	if maxDecimals < 0 {
+		return 0, errors.New("maxDecimals can't be negative")
 	}
 
 	rate, err := ParseRate(skyPerBTC)
@@ -29,7 +32,7 @@ func CalculateBtcSkyValue(satoshis int64, skyPerBTC string) (uint64, error) {
 	btc = btc.DivRound(btcToSatoshi, 8)
 
 	sky := btc.Mul(rate)
-	sky = sky.Truncate(daemon.MaxDropletPrecision)
+	sky = sky.Truncate(int32(maxDecimals))
 
 	skyToDroplets := decimal.New(droplet.Multiplier, 0)
 	droplets := sky.Mul(skyToDroplets)

--- a/src/exchange/calculate_test.go
+++ b/src/exchange/calculate_test.go
@@ -10,76 +10,253 @@ import (
 
 func TestCalculateSkyValue(t *testing.T) {
 	cases := []struct {
-		satoshis int64
-		rate     string
-		result   uint64
-		err      error
+		maxDecimals int
+		satoshis    int64
+		rate        string
+		result      uint64
+		err         error
 	}{
 		{
-			satoshis: -1,
-			rate:     "1",
-			err:      errors.New("satoshis must be greater than or equal to 0"),
+			maxDecimals: 0,
+			satoshis:    -1,
+			rate:        "1",
+			err:         errors.New("satoshis must be greater than or equal to 0"),
 		},
 
 		{
-			satoshis: 1,
-			rate:     "-1",
-			err:      errors.New("rate must be greater than zero"),
+			maxDecimals: 0,
+			satoshis:    1,
+			rate:        "-1",
+			err:         errors.New("rate must be greater than zero"),
 		},
 
 		{
-			satoshis: 1,
-			rate:     "0",
-			err:      errors.New("rate must be greater than zero"),
+			maxDecimals: 0,
+			satoshis:    1,
+			rate:        "0",
+			err:         errors.New("rate must be greater than zero"),
 		},
 
 		{
-			satoshis: 1,
-			rate:     "invalidrate",
-			err:      errors.New("can't convert invalidrate to decimal: exponent is not numeric"),
+			maxDecimals: 0,
+			satoshis:    1,
+			rate:        "invalidrate",
+			err:         errors.New("can't convert invalidrate to decimal: exponent is not numeric"),
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    1,
+			rate:        "12k",
+			err:         errors.New("can't convert 12k to decimal"),
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    1,
+			rate:        "1b",
+			err:         errors.New("can't convert 1b to decimal"),
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    1,
+			rate:        "",
+			err:         errors.New("can't convert  to decimal"),
 		},
 
 		{
-			satoshis: 0,
-			rate:     "1",
-			result:   0,
+			maxDecimals: 0,
+			satoshis:    0,
+			rate:        "1",
+			result:      0,
 		},
 
 		{
-			satoshis: 1e8,
-			rate:     "1",
-			result:   1e6,
+			maxDecimals: 0,
+			satoshis:    1e8,
+			rate:        "1",
+			result:      1e6,
 		},
 
 		{
-			satoshis: 1e8,
-			rate:     "500",
-			result:   500e6,
+			maxDecimals: 0,
+			satoshis:    1e8,
+			rate:        "500",
+			result:      500e6,
 		},
 
 		{
-			satoshis: 100e8,
-			rate:     "500",
-			result:   50000e6,
+			maxDecimals: 0,
+			satoshis:    100e8,
+			rate:        "500",
+			result:      50000e6,
 		},
 
 		{
-			satoshis: 2e5,   // 0.002 BTC
-			rate:     "500", // 500 SKY/BTC = 1 SKY / 0.002 BTC
-			result:   1e6,   // 1 SKY
+			maxDecimals: 0,
+			satoshis:    2e5,   // 0.002 BTC
+			rate:        "500", // 500 SKY/BTC = 1 SKY / 0.002 BTC
+			result:      1e6,   // 1 SKY
 		},
 
 		{
-			satoshis: 1e8, // 1 BTC
-			rate:     "1/2",
-			result:   5e5, // 0.5 SKY
+			maxDecimals: 0,
+			satoshis:    1e8, // 1 BTC
+			rate:        "1/2",
+			result:      0, // 0.5 SKY
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    12345e8, // 12345 BTC
+			rate:        "1/2",
+			result:      6172e6, // 6172 SKY
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    1e8,
+			rate:        "0.0001",
+			result:      0, // 0 SKY
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    12345678, // 0.12345678 BTC
+			rate:        "512",
+			result:      63e6, // 63 SKY
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    123456789, // 1.23456789 BTC
+			rate:        "10000",
+			result:      12345e6, // 12345 SKY
+		},
+		{
+			maxDecimals: 0,
+			satoshis:    876543219e4, // 87654.3219 BTC
+			rate:        "2/3",
+			result:      58436e6, // 58436 SKY
+		},
+
+		{
+			maxDecimals: 1,
+			satoshis:    1e8, // 1 BTC
+			rate:        "1/2",
+			result:      5e5, // 0.5 SKY
+		},
+		{
+			maxDecimals: 1,
+			satoshis:    12345e8, // 12345 BTC
+			rate:        "1/2",
+			result:      6172e6 + 5e5, // 6172.5 SKY
+		},
+		{
+			maxDecimals: 1,
+			satoshis:    1e8,
+			rate:        "0.0001",
+			result:      0, // 0 SKY
+		},
+		{
+			maxDecimals: 1,
+			satoshis:    12345678, // 0.12345678 BTC
+			rate:        "512",
+			result:      63e6 + 2e5, // 63.2 SKY
+		},
+		{
+			maxDecimals: 1,
+			satoshis:    123456789, // 1.23456789 BTC
+			rate:        "10000",
+			result:      12345e6 + 6e5, // 12345.6 SKY
+		},
+		{
+			maxDecimals: 1,
+			satoshis:    876543219e4, // 87654.3219 BTC
+			rate:        "2/3",
+			result:      58436e6 + 2e5, // 58436.2 SKY
+		},
+
+		{
+			maxDecimals: 2,
+			satoshis:    1e8, // 1 BTC
+			rate:        "1/2",
+			result:      5e5, // 0.5 SKY
+		},
+		{
+			maxDecimals: 2,
+			satoshis:    12345e8, // 12345 BTC
+			rate:        "1/2",
+			result:      6172e6 + 5e5, // 6172.5 SKY
+		},
+		{
+			maxDecimals: 2,
+			satoshis:    1e8,
+			rate:        "0.0001",
+			result:      0, // 0 SKY
+		},
+		{
+			maxDecimals: 2,
+			satoshis:    12345678, // 0.12345678 BTC
+			rate:        "512",
+			result:      63e6 + 2e5, // 63.2 SKY
+		},
+		{
+			maxDecimals: 2,
+			satoshis:    123456789, // 1.23456789 BTC
+			rate:        "10000",
+			result:      12345e6 + 6e5 + 7e4, // 12345.67 SKY
+		},
+		{
+			maxDecimals: 2,
+			satoshis:    876543219e4, // 87654.3219 BTC
+			rate:        "2/3",
+			result:      58436e6 + 2e5 + 1e4, // 58436.21 SKY
+		},
+
+		{
+			maxDecimals: 3,
+			satoshis:    1e8, // 1 BTC
+			rate:        "1/2",
+			result:      5e5, // 0.5 SKY
+		},
+		{
+			maxDecimals: 3,
+			satoshis:    12345e8, // 12345 BTC
+			rate:        "1/2",
+			result:      6172e6 + 5e5, // 6172.5 SKY
+		},
+		{
+			maxDecimals: 3,
+			satoshis:    1e8,
+			rate:        "0.0001",
+			result:      0, // 0 SKY
+		},
+		{
+			maxDecimals: 3,
+			satoshis:    12345678, // 0.12345678 BTC
+			rate:        "512",
+			result:      63e6 + 2e5 + 9e3, // 63.209 SKY
+		},
+		{
+			maxDecimals: 3,
+			satoshis:    123456789, // 1.23456789 BTC
+			rate:        "10000",
+			result:      12345e6 + 6e5 + 7e4 + 8e3, // 12345.678 SKY
+		},
+		{
+			maxDecimals: 3,
+			satoshis:    876543219e4, // 87654.3219 BTC
+			rate:        "2/3",
+			result:      58436e6 + 2e5 + 1e4 + 4e3, // 58436.214 SKY
+		},
+
+		{
+			maxDecimals: 4,
+			satoshis:    1e8,
+			rate:        "0.0001",
+			result:      1e2, // 0.0001 SKY
 		},
 	}
 
 	for _, tc := range cases {
-		name := fmt.Sprintf("satoshis=%d rate=%s", tc.satoshis, tc.rate)
+		name := fmt.Sprintf("satoshis=%d rate=%s maxDecimals=%d", tc.satoshis, tc.rate, tc.maxDecimals)
 		t.Run(name, func(t *testing.T) {
-			result, err := CalculateBtcSkyValue(tc.satoshis, tc.rate)
+			result, err := CalculateBtcSkyValue(tc.satoshis, tc.rate, tc.maxDecimals)
 			if tc.err == nil {
 				require.NoError(t, err)
 				require.Equal(t, tc.result, result, "%d != %d", tc.result, result)

--- a/src/exchange/exchange_test.go
+++ b/src/exchange/exchange_test.go
@@ -151,6 +151,7 @@ func (scan *dummyScanner) stop() {
 
 const (
 	testSkyBtcRate  string = "100" // 100 SKY per BTC
+	testMaxDecimals        = 0
 	testSkyAddr            = "2Wbi4wvxC4fkTYMsS2f6HaFfW4pafDjXcQW"
 	testSkyAddr2           = "hs1pyuNgxDLyLaZsnqzQG9U3DKdJsbzNpn"
 	dbScanTimeout          = time.Second * 3
@@ -247,7 +248,7 @@ func TestExchangeRunSend(t *testing.T) {
 	require.NoError(t, err)
 
 	var value int64 = 1e8
-	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate)
+	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
 	txid := e.sender.(*dummySender).predictTxid(t, skyAddr, skySent)
 
@@ -480,7 +481,7 @@ func TestExchangeTxConfirmFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	var value int64 = 1e8
-	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate)
+	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
 	txid := e.sender.(*dummySender).predictTxid(t, skyAddr, skySent)
 
@@ -556,7 +557,7 @@ func TestExchangeQuitBeforeConfirm(t *testing.T) {
 	require.NoError(t, err)
 
 	var value int64 = 1e8
-	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate)
+	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
 	txid := e.sender.(*dummySender).predictTxid(t, skyAddr, skySent)
 
@@ -803,7 +804,7 @@ func testExchangeRunProcessDepositBacklog(t *testing.T, dis []DepositInfo, confi
 		expectedDis[i].Status = StatusDone
 
 		if expectedDis[i].SkySent == 0 {
-			amt, err := CalculateBtcSkyValue(di.DepositValue, e.cfg.Rate)
+			amt, err := CalculateBtcSkyValue(di.DepositValue, e.cfg.Rate, testMaxDecimals)
 			require.NoError(t, err)
 			expectedDis[i].SkySent = amt
 		}
@@ -821,7 +822,7 @@ func TestExchangeProcessUnconfirmedTx(t *testing.T) {
 
 	var depositValue int64 = 1e8
 	s := newDummySender()
-	skySent, err := CalculateBtcSkyValue(depositValue, testSkyBtcRate)
+	skySent, err := CalculateBtcSkyValue(depositValue, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
 	txid1 := s.predictTxid(t, testSkyAddr, skySent)
 	txid2 := s.predictTxid(t, testSkyAddr2, skySent)
@@ -878,7 +879,7 @@ func TestExchangeProcessWaitSendDeposits(t *testing.T) {
 
 	var depositValue int64 = 1e8
 	s := newDummySender()
-	skySent, err := CalculateBtcSkyValue(depositValue, testSkyBtcRate)
+	skySent, err := CalculateBtcSkyValue(depositValue, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
 	txid1 := s.predictTxid(t, testSkyAddr, skySent)
 	txid2 := s.predictTxid(t, testSkyAddr2, skySent)
@@ -926,7 +927,7 @@ func TestExchangeProcessWaitSendDeposits(t *testing.T) {
 		err := e.store.BindAddress(di.SkyAddress, di.DepositAddress)
 		require.NoError(t, err)
 
-		skySent, err := CalculateBtcSkyValue(di.DepositValue, di.ConversionRate)
+		skySent, err := CalculateBtcSkyValue(di.DepositValue, di.ConversionRate, testMaxDecimals)
 		require.NoError(t, err)
 
 		txid := e.sender.(*dummySender).predictTxid(t, di.SkyAddress, skySent)

--- a/src/teller/http.go
+++ b/src/teller/http.go
@@ -497,6 +497,7 @@ type ConfigResponse struct {
 	BtcConfirmationsRequired int64  `json:"btc_confirmations_required"`
 	MaxBoundBtcAddresses     int    `json:"max_bound_btc_addrs"`
 	SkyBtcExchangeRate       string `json:"sky_btc_exchange_rate"`
+	MaxDecimals              int    `json:"max_decimals"`
 }
 
 // ConfigHandler returns the teller configuration
@@ -513,7 +514,8 @@ func ConfigHandler(s *HTTPServer) http.HandlerFunc {
 
 		// Convert the exchange rate to a skycoin balance string
 		rate := s.cfg.SkyExchanger.SkyBtcExchangeRate
-		dropletsPerBTC, err := exchange.CalculateBtcSkyValue(exchange.SatoshisPerBTC, rate)
+		maxDecimals := s.cfg.SkyExchanger.MaxDecimals
+		dropletsPerBTC, err := exchange.CalculateBtcSkyValue(exchange.SatoshisPerBTC, rate, maxDecimals)
 		if err != nil {
 			log.WithError(err).Error("exchange.CalculateBtcSkyValue failed")
 			errorResponse(ctx, w, http.StatusInternalServerError, errInternalServerError)
@@ -531,6 +533,7 @@ func ConfigHandler(s *HTTPServer) http.HandlerFunc {
 			Enabled:                  s.cfg.Web.APIEnabled,
 			BtcConfirmationsRequired: s.cfg.BtcScanner.ConfirmationsRequired,
 			SkyBtcExchangeRate:       skyPerBTC,
+			MaxDecimals:              maxDecimals,
 			MaxBoundBtcAddresses:     s.cfg.Teller.MaxBoundBtcAddresses,
 		}); err != nil {
 			log.WithError(err).Error(err)


### PR DESCRIPTION
Make max decimals allowed in the skycoin transaction a configurable value.

It must be set to a value less than or equal to the number of decimals supported by the network and the vendored skycoin library.

Currently, only 0 decimals are allowed, but skycoin will allow 2 or 3 soon.