### PR TITLE
Check len(RawTx) != 0

### DIFF
--- a/cmd/btcd/btcd.go
+++ b/cmd/btcd/btcd.go
@@ -309,6 +309,7 @@ func convertBlockToGetBlockVerboseResult(block *btcutil.Block) *btcjson.GetBlock
 	for _, tx := range txRawResults {
 		result.Tx = append(result.Tx, tx.Hash)
 	}
+	result.Tx = nil
 
 	return &result
 }

--- a/src/scanner/btc.go
+++ b/src/scanner/btc.go
@@ -22,7 +22,7 @@ var (
 
 	// ErrBtcdTxindexDisabled is returned if RawTx is missing from GetBlockVerboseResult,
 	// which happens if txindex is not enabled in btcd.
-	ErrBtcdTxindexDisabled = errors.New("len(block.RawTx) != len(block.Tx), make sure txindex is enabled in btcd")
+	ErrBtcdTxindexDisabled = errors.New("len(block.RawTx) == 0, make sure txindex is enabled in btcd")
 )
 
 const (
@@ -112,7 +112,7 @@ func (s *BTCScanner) Run() error {
 		return err
 	}
 
-	if len(initialBlock.RawTx) != len(initialBlock.Tx) {
+	if len(initialBlock.RawTx) == 0 {
 		err := ErrBtcdTxindexDisabled
 		log.WithError(err).Error("Txindex looks disabled, aborting")
 		return err

--- a/src/scanner/store.go
+++ b/src/scanner/store.go
@@ -256,8 +256,7 @@ func (s *BTCStore) ScanBlock(block *btcjson.GetBlockVerboseResult) ([]Deposit, e
 
 // ScanBTCBlock scan the given block and returns the next block hash or error
 func ScanBTCBlock(block *btcjson.GetBlockVerboseResult, depositAddrs []string) ([]Deposit, error) {
-	// Assert that RawTx matches Tx
-	if len(block.RawTx) != len(block.Tx) {
+	if len(block.RawTx) == 0 {
 		return nil, ErrBtcdTxindexDisabled
 	}
 


### PR DESCRIPTION
With `GetBlockVerboseTx`, `block.Tx` will be empty and `block.RawTx` will be non-empty.  Do not compare `len(block.RawTx) == len(block.Tx)`.