### PR TITLE
fix api/status cointype is empty when binded without deposit

### DIFF
--- a/cmd/transmit/transmit.go
+++ b/cmd/transmit/transmit.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"log"
+
+	"github.com/boltdb/bolt"
+	"github.com/skycoin/teller/src/util/dbutil"
+)
+
+//delete bucket
+func deleteBucket(db *bolt.DB, bucketName string) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		return tx.DeleteBucket([]byte(bucketName))
+	})
+}
+
+//rename bucket
+func renameBucket(db *bolt.DB, bucketName, newBucketName string) error {
+	newBktName := []byte(newBucketName)
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(newBktName); err != nil {
+			return dbutil.NewCreateBucketFailedErr(newBktName, err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Assume bucket exists and has keys
+		return dbutil.ForEach(tx, []byte(bucketName), func(k, v []byte) error {
+			if err := dbutil.PutBucketValue(tx, newBktName, string(k), v); err != nil {
+				return err
+			}
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	dbname := flag.String("db", "", "db name")
+	oldBkt := flag.String("oldbkt", "", "bucket name to be changed")
+	newBkt := flag.String("newbkt", "", "new bucket name")
+	isDeletedOld := flag.Bool("del", false, "deleted oldbkt or not, default false")
+	flag.Parse()
+	if *dbname == "" {
+		flag.PrintDefaults()
+		log.Fatal(errors.New("require db"))
+	}
+	if *oldBkt == "" {
+		flag.PrintDefaults()
+		log.Fatal(errors.New("require old bucket"))
+	}
+	if *newBkt == "" {
+		flag.PrintDefaults()
+		log.Fatal(errors.New("require new bucket"))
+	}
+	db, err := bolt.Open(*dbname, 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer db.Close()
+
+	err = renameBucket(db, *oldBkt, *newBkt)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("rename bucket %s to %s success\n", *oldBkt, *newBkt)
+	}
+	if *isDeletedOld {
+		if err := deleteBucket(db, *oldBkt); err != nil {
+			log.Fatal(err)
+		} else {
+			log.Printf("delete bucket %s success\n", *oldBkt)
+		}
+	}
+}

--- a/src/exchange/exchange.go
+++ b/src/exchange/exchange.go
@@ -675,6 +675,7 @@ func (s *Exchange) GetBindNum(skyAddr string) (int, error) {
 	return len(addrs), err
 }
 
+//GetDepositStats returns deposit status
 func (s *Exchange) GetDepositStats() (stats *DepositStats, err error) {
 	tbr, tss, err := s.store.GetDepositStats()
 	if err != nil {

--- a/src/exchange/exchange_test.go
+++ b/src/exchange/exchange_test.go
@@ -1266,8 +1266,12 @@ func TestExchangeGetDepositStatuses(t *testing.T) {
 	store, err := NewStore(log, db)
 	require.NoError(t, err)
 	dummyScanner := newDummyScanner()
+	dummyScannerEth := newDummyScanner()
 	multiplexer := scanner.NewMultiplexer(log)
-	multiplexer.AddScanner(dummyScanner, scanner.CoinTypeBTC)
+	err = multiplexer.AddScanner(dummyScanner, scanner.CoinTypeBTC)
+	require.NoError(t, err)
+	err = multiplexer.AddScanner(dummyScannerEth, scanner.CoinTypeETH)
+	require.NoError(t, err)
 
 	s := &Exchange{
 		store:       store,
@@ -1278,18 +1282,28 @@ func TestExchangeGetDepositStatuses(t *testing.T) {
 
 	err = s.BindAddress("a", "b", scanner.CoinTypeBTC)
 	require.NoError(t, err)
+	err = s.BindAddress("a", "e", scanner.CoinTypeETH)
+	require.NoError(t, err)
 
 	// Should be added to dummyScanner
 	require.Len(t, dummyScanner.addrs, 1)
 	require.Equal(t, "b", dummyScanner.addrs[0])
 
+	require.Len(t, dummyScannerEth.addrs, 1)
+	require.Equal(t, "e", dummyScannerEth.addrs[0])
+
 	// Should be in the store
 	depositInfos, err := s.store.GetDepositInfoOfSkyAddress("a")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(depositInfos))
+	require.Equal(t, 2, len(depositInfos))
 	depositInfo := depositInfos[0]
 	require.Equal(t, uint64(0), depositInfo.Seq)
 	require.Equal(t, scanner.CoinTypeBTC, depositInfo.CoinType)
+	require.Equal(t, StatusWaitDeposit, depositInfo.Status)
+	require.NotEmpty(t, depositInfo.UpdatedAt)
+	depositInfo = depositInfos[1]
+	require.Equal(t, uint64(1), depositInfo.Seq)
+	require.Equal(t, scanner.CoinTypeETH, depositInfo.CoinType)
 	require.Equal(t, StatusWaitDeposit, depositInfo.Status)
 	require.NotEmpty(t, depositInfo.UpdatedAt)
 }

--- a/src/exchange/exchange_test.go
+++ b/src/exchange/exchange_test.go
@@ -1259,7 +1259,39 @@ func TestExchangeCreateTransaction(t *testing.T) {
 }
 
 func TestExchangeGetDepositStatuses(t *testing.T) {
-	// TODO
+	db, shutdown := testutil.PrepareDB(t)
+	defer shutdown()
+
+	log, _ := testutil.NewLogger(t)
+	store, err := NewStore(log, db)
+	require.NoError(t, err)
+	dummyScanner := newDummyScanner()
+	multiplexer := scanner.NewMultiplexer(log)
+	multiplexer.AddScanner(dummyScanner, scanner.CoinTypeBTC)
+
+	s := &Exchange{
+		store:       store,
+		multiplexer: multiplexer,
+	}
+
+	require.Len(t, dummyScanner.addrs, 0)
+
+	err = s.BindAddress("a", "b", scanner.CoinTypeBTC)
+	require.NoError(t, err)
+
+	// Should be added to dummyScanner
+	require.Len(t, dummyScanner.addrs, 1)
+	require.Equal(t, "b", dummyScanner.addrs[0])
+
+	// Should be in the store
+	depositInfos, err := s.store.GetDepositInfoOfSkyAddress("a")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(depositInfos))
+	depositInfo := depositInfos[0]
+	require.Equal(t, uint64(0), depositInfo.Seq)
+	require.Equal(t, scanner.CoinTypeBTC, depositInfo.CoinType)
+	require.Equal(t, StatusWaitDeposit, depositInfo.Status)
+	require.NotEmpty(t, depositInfo.UpdatedAt)
 }
 
 func TestExchangeGetDepositStatusDetail(t *testing.T) {

--- a/src/exchange/store.go
+++ b/src/exchange/store.go
@@ -355,7 +355,7 @@ func (s *Store) GetDepositInfoOfSkyAddress(skyAddr string) ([]DepositInfo, error
 
 	if err := s.db.View(func(tx *bolt.Tx) error {
 		// TODO: DB queries in a loop, may need restructuring for performance
-		depositElements, err := s.getSkyBindBtcAddressesTx(tx, skyAddr)
+		depositElements, err := s.getSkyBindAddressesTx(tx, skyAddr)
 		if err != nil {
 			return err
 		}
@@ -461,7 +461,7 @@ func (s *Store) GetSkyBindAddresses(skyAddr string) ([]string, error) {
 
 	if err := s.db.View(func(tx *bolt.Tx) error {
 		var err error
-		elements, err := s.getSkyBindBtcAddressesTx(tx, skyAddr)
+		elements, err := s.getSkyBindAddressesTx(tx, skyAddr)
 		for _, elem := range elements {
 			addrs = append(addrs, elem.DepositAddr)
 		}
@@ -473,8 +473,8 @@ func (s *Store) GetSkyBindAddresses(skyAddr string) ([]string, error) {
 	return addrs, nil
 }
 
-// getSkyBindBtcAddressesTx returns the addresses of the given sky address bound
-func (s *Store) getSkyBindBtcAddressesTx(tx *bolt.Tx, skyAddr string) ([]DepositElement, error) {
+// getSkyBindAddressesTx returns the addresses of the given sky address bound
+func (s *Store) getSkyBindAddressesTx(tx *bolt.Tx, skyAddr string) ([]DepositElement, error) {
 	var addrs []DepositElement
 	if err := dbutil.GetBucketObject(tx, SkyDepositSeqsIndexBkt, skyAddr, &addrs); err != nil {
 		switch err.(type) {

--- a/src/exchange/store_test.go
+++ b/src/exchange/store_test.go
@@ -189,10 +189,11 @@ func TestStoreBindAddress(t *testing.T) {
 		v := bkt.Get([]byte("ba1"))
 		require.Equal(t, "sa1", string(v))
 
-		var addrs []string
+		var addrs []DepositElement
 		err := dbutil.GetBucketObject(tx, SkyDepositSeqsIndexBkt, "sa1", &addrs)
 		require.NoError(t, err)
-		require.Equal(t, "ba1", addrs[0])
+		require.Equal(t, "ba1", addrs[0].DepositAddr)
+		require.Equal(t, scanner.CoinTypeBTC, addrs[0].CoinType)
 		return nil
 	})
 	require.NoError(t, err)

--- a/src/exchange/store_test.go
+++ b/src/exchange/store_test.go
@@ -189,11 +189,10 @@ func TestStoreBindAddress(t *testing.T) {
 		v := bkt.Get([]byte("ba1"))
 		require.Equal(t, "sa1", string(v))
 
-		var addrs []DepositElement
+		var addrs []string
 		err := dbutil.GetBucketObject(tx, SkyDepositSeqsIndexBkt, "sa1", &addrs)
 		require.NoError(t, err)
-		require.Equal(t, "ba1", addrs[0].DepositAddr)
-		require.Equal(t, scanner.CoinTypeBTC, addrs[0].CoinType)
+		require.Equal(t, "ba1", addrs[0])
 		return nil
 	})
 	require.NoError(t, err)

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -58,3 +58,8 @@ type Deposit struct {
 func (d Deposit) ID() string {
 	return fmt.Sprintf("%s:%d", d.Tx, d.N)
 }
+
+// returns supported coin types
+func GetCoinTypes() []string {
+	return []string{CoinTypeBTC, CoinTypeETH}
+}


### PR DESCRIPTION
fixed coin_type is empty only when bind without deposit 
```
curl "http://127.0.0.1:7071/api/status?skyaddr=2GLCDr78aHFb6BLJaoLBc9thGrZxDD9iTgS"
{
    "statuses": [
        {
            "seq": 0,
            "updated_at": 1514684790,
            "status": "waiting_deposit",
            "coin_type": ""
        }
 ]
}
```