### PR TITLE
Refactor Exchange into components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 cert-cache
 *.ignore.*
 *.wlt
+cover.out
+coverage.html

--- a/README.md
+++ b/README.md
@@ -372,6 +372,10 @@ multiple BTC/ETH addresses. The default maximum number of bound addresses is 5.
 Coin type specifies which coin deposit address type to generate.
 Options are: BTC/ETH [TODO: support more coin types].
 
+"buy_method" in the response, indicates the purchasing mode.
+"direct" buy method is a fixed-price purchase directly from the wallet.
+"passthrough" but method is a variable-price purchase through an exchange.
+
 Returns `403 Forbidden` if `teller.bind_enabled` is `false`.
 
 Example:
@@ -386,6 +390,7 @@ Response:
 {
     "deposit_address": "1Bmp9Kv9vcbjNKfdxCrmL1Ve5n7gvkDoNp",
     "coin_type": "BTC",
+    "buy_method": "direct"
 }
 ```
 ETH example:

--- a/cmd/dbfix/dbfix.go
+++ b/cmd/dbfix/dbfix.go
@@ -13,6 +13,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/teller/src/exchange"
+	"github.com/skycoin/teller/src/scanner"
 )
 
 const usage = `dbfix <dbfile>
@@ -81,7 +82,7 @@ func fixBindAddressBkt(db *bolt.DB) error {
 
 	var invalidBtcAddrs [][]byte
 	if err := db.View(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(exchange.BindAddressBkt)
+		bkt := tx.Bucket(exchange.MustGetBindAddressBkt(scanner.CoinTypeBTC))
 		if bkt == nil {
 			return errors.New("BindAddressBkt not found in db")
 		}
@@ -101,7 +102,7 @@ func fixBindAddressBkt(db *bolt.DB) error {
 
 	fmt.Printf("Repairing BindAddressBkt, %d invalid addresses\n", len(invalidBtcAddrs))
 	return db.Update(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(exchange.BindAddressBkt)
+		bkt := tx.Bucket(exchange.MustGetBindAddressBkt(scanner.CoinTypeBTC))
 		for _, a := range invalidBtcAddrs {
 			v := bkt.Get(a)
 			if v == nil {

--- a/cmd/teller/teller.go
+++ b/cmd/teller/teller.go
@@ -161,7 +161,7 @@ func run() error {
 	}
 
 	errC := make(chan error, 20)
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
 
 	background := func(name string, errC chan<- error, f func() error) {
 		log.Infof("Backgrounding task %s", name)
@@ -278,9 +278,9 @@ func run() error {
 		log.WithError(err).Error("exchange.NewStore failed")
 		return err
 	}
-	exchangeClient, err := exchange.NewExchange(log, exchangeStore, multiplexer, sendRPC, cfg.SkyExchanger)
+	exchangeClient, err := exchange.NewDirectExchange(log, cfg.SkyExchanger, exchangeStore, multiplexer, sendRPC)
 	if err != nil {
-		log.WithError(err).Error("exchange.NewExchange failed")
+		log.WithError(err).Error("exchange.NewDirectExchange failed")
 		return err
 	}
 

--- a/src/exchange/calculate.go
+++ b/src/exchange/calculate.go
@@ -11,6 +11,13 @@ import (
 	"github.com/skycoin/teller/src/util/mathutil"
 )
 
+const (
+	// SatoshisPerBTC is the number of satoshis per 1 BTC
+	SatoshisPerBTC int64 = 1e8
+	// WeiPerETH is the number of wei per 1 ETH
+	WeiPerETH int64 = 1e18
+)
+
 // CalculateBtcSkyValue returns the amount of SKY (in droplets) to give for an
 // amount of BTC (in satoshis).
 // Rate is measured in SKY per BTC. It should be a decimal string.

--- a/src/exchange/deposit.go
+++ b/src/exchange/deposit.go
@@ -119,6 +119,13 @@ func (di DepositInfo) ValidateForStatus() error {
 		if _, err := mathutil.ParseRate(di.ConversionRate); err != nil {
 			return err
 		}
+		switch di.BuyMethod {
+		case BuyMethodDirect, BuyMethodPassthrough:
+		case "":
+			return errors.New("BuyMethod missing")
+		default:
+			return errors.New("BuyMethod invalid")
+		}
 
 		return nil
 	}
@@ -144,6 +151,9 @@ func (di DepositInfo) ValidateForStatus() error {
 		return checkWaitSend()
 
 	case StatusWaitSend:
+		return checkWaitSend()
+
+	case StatusWaitDecide:
 		return checkWaitSend()
 
 	case StatusWaitDeposit, StatusUnknown:

--- a/src/exchange/deposit.go
+++ b/src/exchange/deposit.go
@@ -16,7 +16,7 @@ type Status int8
 const (
 	// StatusWaitDeposit deposit has not occurred
 	StatusWaitDeposit Status = iota
-	// StatusWaitSend deposit received, but send has not occurred
+	// StatusWaitSend deposit is ready for send
 	StatusWaitSend
 	// StatusWaitConfirm coins sent, but not confirmed yet
 	StatusWaitConfirm
@@ -24,6 +24,8 @@ const (
 	StatusDone
 	// StatusUnknown fallback value
 	StatusUnknown
+	// StatusWaitDecide initial deposit receive state
+	StatusWaitDecide
 )
 
 var statusString = []string{
@@ -32,6 +34,7 @@ var statusString = []string{
 	StatusWaitConfirm: "waiting_confirm",
 	StatusDone:        "done",
 	StatusUnknown:     "unknown",
+	StatusWaitDecide:  "waiting_decide",
 }
 
 func (s Status) String() string {
@@ -49,18 +52,29 @@ func NewStatusFromStr(st string) Status {
 		return StatusWaitConfirm
 	case statusString[StatusDone]:
 		return StatusDone
+	case statusString[StatusWaitDecide]:
+		return StatusWaitDecide
 	default:
 		return StatusUnknown
 	}
+}
+
+// BoundAddress records information about an address binding
+type BoundAddress struct {
+	SkyAddress string
+	Address    string
+	CoinType   string
+	BuyMethod  string
 }
 
 // DepositInfo records the deposit info
 type DepositInfo struct {
 	Seq            uint64
 	UpdatedAt      int64
-	Status         Status
+	Status         Status // TODO -- migrate to string statuses?
 	CoinType       string
 	SkyAddress     string
+	BuyMethod      string
 	DepositAddress string
 	DepositID      string
 	Txid           string

--- a/src/exchange/direct_buy.go
+++ b/src/exchange/direct_buy.go
@@ -64,7 +64,7 @@ func (p *DirectBuy) Run() error {
 		p.runUpdateStatus()
 	}()
 
-	wg.Done()
+	wg.Wait()
 
 	return nil
 }

--- a/src/exchange/direct_buy.go
+++ b/src/exchange/direct_buy.go
@@ -1,0 +1,121 @@
+package exchange
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/teller/src/config"
+)
+
+// Processor is a component that processes deposits from a Receiver and sends them to a Sender
+type Processor interface {
+	Deposits() <-chan DepositInfo
+}
+
+// ProcessRunner is a Processor that can be run
+type ProcessRunner interface {
+	Runner
+	Processor
+}
+
+// DirectBuy implements a Processor. All deposits are sent directly to the sender for processing.
+type DirectBuy struct {
+	log      logrus.FieldLogger
+	cfg      config.SkyExchanger
+	receiver Receiver
+	store    Storer
+	deposits chan DepositInfo
+	quit     chan struct{}
+	done     chan struct{}
+}
+
+// NewDirectBuy creates DirectBuy
+func NewDirectBuy(log logrus.FieldLogger, cfg config.SkyExchanger, store Storer, receiver Receiver) (*DirectBuy, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &DirectBuy{
+		log:      log.WithField("prefix", "teller.exchange.directbuy"),
+		cfg:      cfg,
+		store:    store,
+		receiver: receiver,
+		deposits: make(chan DepositInfo, 100),
+		quit:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Run updates all deposits with StatusWaitSend and exposes them over Deposits()
+func (p *DirectBuy) Run() error {
+	log := p.log
+	log.Info("Start direct buy service...")
+	defer func() {
+		log.Info("Closed direct buy service")
+		p.done <- struct{}{}
+	}()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		p.runUpdateStatus()
+	}()
+
+	wg.Done()
+
+	return nil
+}
+
+// runUpdateStatus reads deposits from the Receiver and changes their status to StatusWaitSend
+func (p *DirectBuy) runUpdateStatus() {
+	log := p.log.WithField("goroutine", "runUpdateStatus")
+	for {
+		select {
+		case <-p.quit:
+			log.Info("quit")
+			return
+		case d := <-p.receiver.Deposits():
+			updatedDeposit, err := p.updateStatus(d)
+			if err != nil {
+				log.WithError(err).Error("updateStatus failed.  This deposit will not be reprocessed until teller is restarted.")
+				continue
+			}
+
+			p.deposits <- updatedDeposit
+		}
+	}
+}
+
+// Shutdown stops a previous call to Run
+func (p *DirectBuy) Shutdown() {
+	p.log.Info("Shutting down DirectBuy")
+	close(p.quit)
+	p.log.Info("Waiting for run to finish")
+	<-p.done
+	p.log.Info("Shutdown complete")
+}
+
+// Deposits returns a channel of processed deposits
+func (p *DirectBuy) Deposits() <-chan DepositInfo {
+	return p.deposits
+}
+
+// updateStatus sets the deposit's status to StatusWaitSend.
+// The deposit will be picked up by the Send component which will send the coins.
+// The fixed exchange rate is already set by the receiver when it creates the deposit, so no other action is needed.
+// TODO -- set the rate here instead?
+func (p *DirectBuy) updateStatus(di DepositInfo) (DepositInfo, error) {
+	updatedDi, err := p.store.UpdateDepositInfo(di.DepositID, func(di DepositInfo) DepositInfo {
+		di.Status = StatusWaitSend
+		return di
+	})
+	if err != nil {
+		p.log.WithError(err).Error("UpdateDepositInfo set StatusWaitSend failed")
+		return di, err
+	}
+
+	return updatedDi, nil
+}

--- a/src/exchange/direct_buy.go
+++ b/src/exchange/direct_buy.go
@@ -80,7 +80,8 @@ func (p *DirectBuy) runUpdateStatus() {
 		case d := <-p.receiver.Deposits():
 			updatedDeposit, err := p.updateStatus(d)
 			if err != nil {
-				log.WithError(err).Error("updateStatus failed.  This deposit will not be reprocessed until teller is restarted.")
+				msg := "runUpdateStatus failed. This deposit will not be reprocessed until teller is restarted."
+				log.WithField("depositInfo", d).WithError(err).Error(msg)
 				continue
 			}
 

--- a/src/exchange/exchange.go
+++ b/src/exchange/exchange.go
@@ -165,7 +165,7 @@ func (e *Exchange) Run() error {
 		e.log.WithError(err).Error("Terminating early")
 	}
 
-	wg.Done()
+	wg.Wait()
 
 	return err
 }

--- a/src/exchange/exchange.go
+++ b/src/exchange/exchange.go
@@ -60,7 +60,7 @@ type Runner interface {
 
 // Exchanger provides APIs to interact with the exchange service
 type Exchanger interface {
-	BindAddress(skyAddr, depositAddr, coinType string) error
+	BindAddress(skyAddr, depositAddr, coinType string) (*BoundAddress, error)
 	GetDepositStatuses(skyAddr string) ([]DepositStatus, error)
 	GetDepositStatusDetail(flt DepositFilter) ([]DepositStatusDetail, error)
 	GetBindNum(skyAddr string) (int, error)
@@ -279,6 +279,6 @@ func (e *Exchange) Status() error {
 // add the btc/eth address to scan service, when detect deposit coin
 // to the btc/eth address, will send specific skycoin to the binded
 // skycoin address
-func (e *Exchange) BindAddress(skyAddr, depositAddr, coinType string) error {
+func (e *Exchange) BindAddress(skyAddr, depositAddr, coinType string) (*BoundAddress, error) {
 	return e.Receiver.BindAddress(skyAddr, depositAddr, coinType, e.buyMethod)
 }

--- a/src/exchange/exchange.go
+++ b/src/exchange/exchange.go
@@ -107,6 +107,7 @@ func NewDirectExchange(log logrus.FieldLogger, cfg config.SkyExchanger, store St
 	return &Exchange{
 		log:       log.WithField("prefix", "teller.exchange.exchange"),
 		store:     store,
+		cfg:       cfg,
 		buyMethod: BuyMethodDirect,
 		quit:      make(chan struct{}),
 		done:      make(chan struct{}),

--- a/src/exchange/exchange.go
+++ b/src/exchange/exchange.go
@@ -2,29 +2,25 @@ package exchange
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skycoin/src/api/cli"
-	"github.com/skycoin/skycoin/src/coin"
-	"github.com/skycoin/skycoin/src/util/droplet"
 
 	"github.com/skycoin/teller/src/config"
 	"github.com/skycoin/teller/src/scanner"
 	"github.com/skycoin/teller/src/sender"
-	"github.com/skycoin/teller/src/util/mathutil"
 )
 
 const (
-	// SatoshisPerBTC is the number of satoshis per 1 BTC
-	SatoshisPerBTC int64 = 1e8
-	// WeiPerETH is the number of wei per 1 ETH
-	WeiPerETH int64 = 1e18
-
 	txConfirmationCheckWait = time.Second * 3
+
+	// BuyMethodDirect is used when buying directly from the local hot wallet
+	BuyMethodDirect = "direct"
+	// BuyMethodPassthrough is used when coins are first bought from an exchange before sending from the local hot wallet
+	BuyMethodPassthrough = "passthrough"
 )
 
 var (
@@ -39,10 +35,28 @@ var (
 	ErrDepositStatusInvalid = errors.New("Deposit status cannot be handled")
 	// ErrNoBoundAddress is returned if no skycoin address is bound to a deposit's address
 	ErrNoBoundAddress = errors.New("Deposit has no bound skycoin address")
+	// ErrInvalidBuyMethod is returned if BindAddress is called with an invalid buy method
+	ErrInvalidBuyMethod = errors.New("Invalid buy method")
 )
+
+// ValidateBuyMethod returns an error if a buy method string is invalid
+func ValidateBuyMethod(m string) error {
+	switch m {
+	case BuyMethodDirect, BuyMethodPassthrough:
+		return nil
+	default:
+		return ErrInvalidBuyMethod
+	}
+}
 
 // DepositFilter filters deposits
 type DepositFilter func(di DepositInfo) bool
+
+// Runner defines an interface for components that can be started and stopped
+type Runner interface {
+	Run() error
+	Shutdown()
+}
 
 // Exchanger provides APIs to interact with the exchange service
 type Exchanger interface {
@@ -55,546 +69,120 @@ type Exchanger interface {
 	Balance() (*cli.Balance, error)
 }
 
-// Exchange manages coin exchange between deposits and skycoin
+// Exchange encompasses an entire coin<>skycoin deposit-process-send flow
 type Exchange struct {
-	log         logrus.FieldLogger
-	cfg         config.SkyExchanger
-	multiplexer *scanner.Multiplexer // multiplex provides APIs for interacting with the scan service
-	sender      sender.Sender        // sender provides APIs for sending skycoin
-	store       Storer               // deposit info storage
-	quit        chan struct{}
-	done        chan struct{}
-	depositChan chan DepositInfo
-	statusLock  sync.RWMutex
-	status      error
+	log       logrus.FieldLogger
+	store     Storer
+	cfg       config.SkyExchanger
+	buyMethod string
+	quit      chan struct{}
+	done      chan struct{}
+
+	Receiver  ReceiveRunner
+	Processor ProcessRunner
+	Sender    SendRunner
 }
 
-// NewExchange creates exchange service
-func NewExchange(log logrus.FieldLogger, store Storer, multiplexer *scanner.Multiplexer, sender sender.Sender, cfg config.SkyExchanger) (*Exchange, error) {
+// NewDirectExchange creates an Exchange which performs "direct buy", i.e. directly selling from a local skycoin wallet
+func NewDirectExchange(log logrus.FieldLogger, cfg config.SkyExchanger, store Storer, multiplexer *scanner.Multiplexer, coinSender sender.Sender) (*Exchange, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
-	if cfg.TxConfirmationCheckWait == 0 {
-		cfg.TxConfirmationCheckWait = txConfirmationCheckWait
+	receiver, err := NewReceive(log, cfg, store, multiplexer)
+	if err != nil {
+		return nil, err
+	}
+
+	processor, err := NewDirectBuy(log, cfg, store, receiver)
+	if err != nil {
+		return nil, err
+	}
+
+	sender, err := NewSend(log, cfg, store, coinSender, processor)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Exchange{
-		cfg:         cfg,
-		log:         log.WithField("prefix", "teller.exchange"),
-		multiplexer: multiplexer,
-		sender:      sender,
-		store:       store,
-		quit:        make(chan struct{}),
-		done:        make(chan struct{}, 1),
-		depositChan: make(chan DepositInfo, 100),
+		log:       log.WithField("prefix", "teller.exchange.exchange"),
+		store:     store,
+		buyMethod: BuyMethodDirect,
+		quit:      make(chan struct{}),
+		done:      make(chan struct{}),
+		Receiver:  receiver,
+		Processor: processor,
+		Sender:    sender,
 	}, nil
 }
 
-// Run starts the exchange process
-func (s *Exchange) Run() error {
-	log := s.log
-	log.Info("Start exchange service...")
+// Run runs all components of the Exchange
+func (e *Exchange) Run() error {
+	e.log.Info("Start exchange service...")
 	defer func() {
-		log.Info("Closed exchange service")
-		s.done <- struct{}{}
+		e.log.Info("Closed exchange service")
+		e.done <- struct{}{}
 	}()
 
+	// TODO: Alternative way of managing the subcomponents:
+	// Create channels for linking two components, initialize the components with the channels
+	// Close them to teardown
+
+	errC := make(chan error, 3)
 	var wg sync.WaitGroup
 
-	if s.cfg.SendEnabled {
-		// Load StatusWaitSend deposits for processing later
-		waitSendDeposits, err := s.store.GetDepositInfoArray(func(di DepositInfo) bool {
-			return di.Status == StatusWaitSend
-		})
-
-		if err != nil {
-			err = fmt.Errorf("GetDepositInfoArray failed: %v", err)
-			log.WithError(err).Error(err)
-			return err
-		}
-
-		// Load StatusWaitConfirm deposits for processing later
-		waitConfirmDeposits, err := s.store.GetDepositInfoArray(func(di DepositInfo) bool {
-			return di.Status == StatusWaitConfirm
-		})
-
-		if err != nil {
-			err = fmt.Errorf("GetDepositInfoArray failed: %v", err)
-			log.WithError(err).Error(err)
-			return err
-		}
-
-		// This loop processes StatusWaitSend deposits.
-		// Only one deposit is processed at a time; it will not send more coins
-		// until it receives confirmation of the previous send.
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			log := log.WithField("goroutine", "sendSky")
-			for {
-				select {
-				case <-s.quit:
-					log.Info("exchange.Exchange send loop quit")
-					return
-				case d := <-s.depositChan:
-					log := log.WithField("depositInfo", d)
-					if err := s.processWaitSendDeposit(d); err != nil {
-						log.WithError(err).Error("processWaitSendDeposit failed. This deposit will not be reprocessed until teller is restarted.")
-					}
-				}
-			}
-		}()
-
-		// Queue the saved StatusWaitConfirm deposits
-		for _, di := range waitConfirmDeposits {
-			s.depositChan <- di
-		}
-
-		// Queue the saved StatusWaitSend deposits
-		for _, di := range waitSendDeposits {
-			s.depositChan <- di
-		}
-	}
-
-	// This loop processes incoming deposits from the scanner and saves a
-	// new DepositInfo with a status of StatusWaitSend
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-
-		log := log.WithField("goroutine", "watchDeposits")
-		for {
-			var dv scanner.DepositNote
-			var ok bool
-			select {
-			case <-s.quit:
-				log.Info("exchange.Exchange watch deposits loop quit")
-				return
-			case dv, ok = <-s.multiplexer.GetDeposit():
-				if !ok {
-					log.Warn("Scan service closed, watch deposits loop quit")
-					return
-				}
-
-			}
-			log := log.WithField("deposit", dv.Deposit)
-
-			// Save a new DepositInfo based upon the scanner.Deposit.
-			// If the save fails, report it to the scanner.
-			// The scanner will mark the deposit as "processed" if no error
-			// occurred.  Any unprocessed deposits held by the scanner
-			// will be resent to the exchange when teller is started.
-			if d, err := s.saveIncomingDeposit(dv.Deposit); err != nil {
-				log.WithError(err).Error("saveIncomingDeposit failed. This deposit will not be reprocessed until teller is restarted.")
-				dv.ErrC <- err
-			} else {
-				dv.ErrC <- nil
-				if s.cfg.SendEnabled {
-					s.depositChan <- d
-				}
-			}
+		if err := e.Receiver.Run(); err != nil {
+			e.log.WithError(err).Error("Receiver.Run failed")
+			errC <- err
 		}
 	}()
 
-	wg.Wait()
-
-	return nil
-}
-
-// Shutdown close the exchange service
-func (s *Exchange) Shutdown() {
-	close(s.quit)
-	s.log.Info("Waiting for Run() to finish")
-	<-s.done
-	s.log.Info("Shutdown complete")
-}
-
-//getRate returns conversion rate according to coin type
-func (s *Exchange) getRate(coinType string) (string, error) {
-	switch coinType {
-	case scanner.CoinTypeBTC:
-		s.log.Info("Received bitcoin deposit")
-		return s.cfg.SkyBtcExchangeRate, nil
-	case scanner.CoinTypeETH:
-		s.log.Info("Received ethcoin deposit")
-		return s.cfg.SkyEthExchangeRate, nil
-	default:
-		s.log.WithError(scanner.ErrUnsupportedCoinType).Error()
-		return "", scanner.ErrUnsupportedCoinType
-	}
-}
-
-// saveIncomingDeposit is called when receiving a deposit from the scanner
-func (s *Exchange) saveIncomingDeposit(dv scanner.Deposit) (DepositInfo, error) {
-	log := s.log.WithField("deposit", dv)
-
-	var rate string
-	rate, err := s.getRate(dv.CoinType)
-	if err != nil {
-		log.WithError(err).Error("get conversion rate failed")
-		return DepositInfo{}, err
-	}
-
-	di, err := s.store.GetOrCreateDepositInfo(dv, rate)
-	if err != nil {
-		log.WithError(err).Error("GetOrCreateDepositInfo failed")
-		return DepositInfo{}, err
-	}
-
-	log = log.WithField("depositInfo", di)
-	log.Info("Saved DepositInfo")
-
-	return di, err
-}
-
-// processDeposit advances a single deposit through three states:
-// StatusWaitSend -> StatusWaitConfirm
-// StatusWaitConfirm -> StatusDone
-// StatusWaitDeposit is never saved to the database, so it does not transition
-func (s *Exchange) processWaitSendDeposit(di DepositInfo) error {
-	log := s.log.WithField("depositInfo", di)
-	log.Info("Processing StatusWaitSend deposit")
-
-	for {
-		select {
-		case <-s.quit:
-			return nil
-		default:
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := e.Processor.Run(); err != nil {
+			e.log.WithError(err).Error("Processor.Run failed")
+			errC <- err
 		}
+	}()
 
-		log.Info("handleDepositInfoState")
-
-		var err error
-		di, err = s.handleDepositInfoState(di)
-		log = log.WithField("depositInfo", di)
-
-		s.setStatus(err)
-
-		switch err.(type) {
-		case sender.RPCError:
-			// Treat skycoin RPC/CLI errors as temporary.
-			// Some RPC/CLI errors are hypothetically permanent,
-			// but most likely it is an insufficient wallet balance or
-			// the skycoin node is unavailable.
-			// A permanent error suggests a bug in skycoin or teller so can be fixed.
-			log.WithError(err).Error("handleDepositInfoState failed")
-			select {
-			case <-time.After(s.cfg.TxConfirmationCheckWait):
-			case <-s.quit:
-				return nil
-			}
-		default:
-			switch err {
-			case nil:
-				break
-			case ErrNotConfirmed:
-				select {
-				case <-time.After(s.cfg.TxConfirmationCheckWait):
-				case <-s.quit:
-					return nil
-				}
-			default:
-				log.WithError(err).Error("handleDepositInfoState failed")
-				return err
-			}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := e.Sender.Run(); err != nil {
+			e.log.WithError(err).Error("Sender.Run failed")
+			errC <- err
 		}
+	}()
 
-		if di.Status == StatusDone {
-			return nil
-		}
-	}
-}
-
-func (s *Exchange) handleDepositInfoState(di DepositInfo) (DepositInfo, error) {
-	log := s.log.WithField("deposit", di)
-
-	if err := di.ValidateForStatus(); err != nil {
-		log.WithError(err).Error("handleDepositInfoState's DepositInfo is invalid")
-		return di, err
-	}
-
-	switch di.Status {
-	case StatusWaitSend:
-		// Prepare skycoin transaction
-		skyTx, err := s.createTransaction(di)
-
-		if err != nil {
-			log.WithError(err).Error("createTransaction failed")
-
-			// If the send amount is empty, skip to StatusDone.
-			if err == ErrEmptySendAmount {
-				log.Info("Send amount is 0, skipping to StatusDone")
-				di, err = s.store.UpdateDepositInfo(di.DepositID, func(di DepositInfo) DepositInfo {
-					di.Status = StatusDone
-					di.Error = ErrEmptySendAmount.Error()
-					return di
-				})
-				if err != nil {
-					log.WithError(err).Error("Update DepositInfo set StatusDone failed")
-					return di, err
-				}
-
-				log.WithError(ErrEmptySendAmount).Info("DepositInfo set to StatusDone")
-
-				return di, nil
-			}
-
-			return di, err
-		}
-
-		// Find the coins from the skyTx
-		// The skyTx contains one output sent to the destination address,
-		// so this check is safe.
-		// It is verified earlier by verifyCreatedTransaction
-		var skySent uint64
-		for _, o := range skyTx.Out {
-			if o.Address.String() == di.SkyAddress {
-				skySent = o.Coins
-				break
-			}
-		}
-
-		if skySent == 0 {
-			err := errors.New("No output to destination address found in transaction")
-			log.WithError(err).Error(err)
-			return di, err
-		}
-
-		// Within a bolt.DB transaction, update the db then send the coins
-		// If the send fails, the data is rolled back
-		// If the db save fails, no coins had been sent
-		di, err = s.store.UpdateDepositInfoCallback(di.DepositID, func(di DepositInfo) DepositInfo {
-			di.Status = StatusWaitConfirm
-			di.Txid = skyTx.TxIDHex()
-			di.SkySent = skySent
-			return di
-		}, func(di DepositInfo) error {
-			// NOTE: broadcastTransaction retries indefinitely on error
-			// If the skycoin node is not reachable, this will block,
-			// which will also block the database since it's in a transaction
-			rsp, err := s.broadcastTransaction(skyTx)
-			if err != nil {
-				log.WithError(err).Error("broadcastTransaction failed")
-				return err
-			}
-
-			// Invariant assertion: do not return this as an error, since
-			// coins have been sent. This should never occur.
-			if rsp.Txid != skyTx.TxIDHex() {
-				log.Error("CRITICAL ERROR: BroadcastTxResponse.Txid != skyTx.TxIDHex()")
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			log.WithError(err).Error("store.UpdateDepositInfoCallback failed")
-			return di, err
-		}
-
-		log.Info("DepositInfo set to StatusWaitConfirm")
-
-		return di, nil
-
-	case StatusWaitConfirm:
-		// Wait for confirmation
-		rsp := s.sender.IsTxConfirmed(di.Txid)
-
-		if rsp == nil {
-			log.WithError(ErrNoResponse).Warn("Sender closed")
-			return di, ErrNoResponse
-		}
-
-		if rsp.Err != nil {
-			log.WithError(rsp.Err).Error("IsTxConfirmed failed")
-			return di, rsp.Err
-		}
-
-		if !rsp.Confirmed {
-			log.Info("Transaction is not confirmed yet")
-			return di, ErrNotConfirmed
-		}
-
-		log.Info("Transaction is confirmed")
-
-		di, err := s.store.UpdateDepositInfo(di.DepositID, func(di DepositInfo) DepositInfo {
-			di.Status = StatusDone
-			return di
-		})
-		if err != nil {
-			log.WithError(err).Error("UpdateDepositInfo set StatusDone failed")
-			return di, err
-		}
-
-		log.Info("DepositInfo status set to StatusDone")
-
-		return di, nil
-
-	case StatusDone:
-		log.Warn("DepositInfo already processed")
-		return di, nil
-
-	case StatusWaitDeposit:
-		// We don't save any deposits with StatusWaitDeposit.
-		// We can't transition to StatusWaitSend without a scanner.Deposit
-		log.Error("StatusWaitDeposit cannot be processed and should never be handled by this method")
-		fallthrough
-	case StatusUnknown:
-		fallthrough
-	default:
-		err := ErrDepositStatusInvalid
-		log.WithError(err).Error(err)
-		return di, err
-	}
-}
-
-func (s *Exchange) calculateSkyDroplets(di DepositInfo) (uint64, error) {
-	log := s.log
 	var err error
-	var skyAmt uint64
-	switch di.CoinType {
-	case scanner.CoinTypeBTC:
-		skyAmt, err = CalculateBtcSkyValue(di.DepositValue, di.ConversionRate, s.cfg.MaxDecimals)
-		if err != nil {
-			log.WithError(err).Error("CalculateBtcSkyValue failed")
-			return 0, err
-		}
-	case scanner.CoinTypeETH:
-		//Gwei convert to wei, because stored-value is Gwei in case overflow of uint64
-		skyAmt, err = CalculateEthSkyValue(mathutil.Gwei2Wei(di.DepositValue), di.ConversionRate, s.cfg.MaxDecimals)
-		if err != nil {
-			log.WithError(err).Error("CalculateEthSkyValue failed")
-			return 0, err
-		}
-	default:
-		log.WithError(scanner.ErrUnsupportedCoinType).Error()
-		return 0, scanner.ErrUnsupportedCoinType
+	select {
+	case <-e.quit:
+	case err = <-errC:
+		e.log.WithError(err).Error("Terminating early")
 	}
-	return skyAmt, nil
+
+	wg.Done()
+
+	return err
 }
 
-func (s *Exchange) createTransaction(di DepositInfo) (*coin.Transaction, error) {
-	log := s.log.WithField("deposit", di)
+// Shutdown stops a previous call to run
+func (e *Exchange) Shutdown() {
+	e.log.Info("Shutting down Exchange")
+	close(e.quit)
 
-	// This should never occur, the DepositInfo is saved with a SkyAddress
-	// during GetOrCreateDepositInfo().
-	if di.SkyAddress == "" {
-		err := ErrNoBoundAddress
-		log.WithError(err).Error(err)
-		return nil, err
-	}
+	e.log.Info("Shutting down Exchange subcomponents")
+	e.Receiver.Shutdown()
+	e.Processor.Shutdown()
+	e.Sender.Shutdown()
 
-	log = log.WithField("skyAddr", di.SkyAddress)
-	log = log.WithField("skyRate", di.ConversionRate)
-	log = log.WithField("maxDecimals", s.cfg.MaxDecimals)
-
-	skyAmt, err := s.calculateSkyDroplets(di)
-	if err != nil {
-		log.WithError(err).Error("calculateSkyDroplets failed")
-		return nil, err
-	}
-	skyAmtCoins, err := droplet.ToString(skyAmt)
-	if err != nil {
-		log.WithError(err).Error("droplet.ToString failed")
-		return nil, err
-	}
-
-	log = log.WithField("sendAmtDroplets", skyAmt)
-	log = log.WithField("sendAmtCoins", skyAmtCoins)
-
-	log.Info("Creating skycoin transaction")
-
-	if skyAmt == 0 {
-		err := ErrEmptySendAmount
-		log.WithError(err).Error(err)
-		return nil, err
-	}
-
-	tx, err := s.sender.CreateTransaction(di.SkyAddress, skyAmt)
-	if err != nil {
-		log.WithError(err).Error("sender.CreateTransaction failed")
-		return nil, err
-	}
-
-	log = log.WithField("transactionOutput", tx.Out)
-
-	if err := verifyCreatedTransaction(tx, di, skyAmt); err != nil {
-		log.WithError(err).Error("verifyCreatedTransaction failed")
-		return nil, err
-	}
-
-	return tx, nil
-}
-
-func verifyCreatedTransaction(tx *coin.Transaction, di DepositInfo, skyAmt uint64) error {
-	// Check invariant assertions:
-	// The transaction should contain one output to the destination address.
-	// It may or may not have a change output.
-	count := 0
-
-	for _, o := range tx.Out {
-		if o.Address.String() != di.SkyAddress {
-			continue
-		}
-
-		count++
-
-		if o.Coins != skyAmt {
-			return errors.New("CreateTransaction transaction coins are different")
-		}
-	}
-
-	if count == 0 {
-		return fmt.Errorf("CreateTransaction transaction has no output to address %s", di.SkyAddress)
-	} else if count > 1 {
-		return fmt.Errorf("CreateTransaction transaction has multiple outputs to address %s", di.SkyAddress)
-	}
-
-	return nil
-}
-
-func (s *Exchange) broadcastTransaction(tx *coin.Transaction) (*sender.BroadcastTxResponse, error) {
-	log := s.log.WithField("txid", tx.TxIDHex())
-
-	log.Info("Broadcasting skycoin transaction")
-
-	rsp := s.sender.BroadcastTransaction(tx)
-
-	log = log.WithField("sendRsp", rsp)
-
-	if rsp == nil {
-		err := ErrNoResponse
-		log.WithError(err).Warn("Sender closed")
-		return nil, err
-	}
-
-	if rsp.Err != nil {
-		err := fmt.Errorf("Send skycoin failed: %v", rsp.Err)
-		log.WithError(err).Error(err)
-		return nil, err
-	}
-
-	log.Info("Sent skycoin")
-
-	return rsp, nil
-}
-
-// BindAddress binds deposit address with skycoin address, and
-// add the btc/eth address to scan service, when detect deposit coin
-// to the btc/eth address, will send specific skycoin to the binded
-// skycoin address
-func (s *Exchange) BindAddress(skyAddr, depositAddr, coinType string) error {
-	if err := s.multiplexer.ValidateCoinType(coinType); err != nil {
-		return err
-	}
-
-	if err := s.store.BindAddress(skyAddr, depositAddr, coinType); err != nil {
-		return err
-	}
-
-	return s.multiplexer.AddScanAddress(depositAddr, coinType)
+	e.log.Info("Waiting for run to finish")
+	<-e.done
+	e.log.Info("Shutdown complete")
 }
 
 // DepositStatus json struct for deposit status
@@ -617,8 +205,8 @@ type DepositStatusDetail struct {
 }
 
 // GetDepositStatuses returns deamon.DepositStatus array of given skycoin address
-func (s *Exchange) GetDepositStatuses(skyAddr string) ([]DepositStatus, error) {
-	dis, err := s.store.GetDepositInfoOfSkyAddress(skyAddr)
+func (e *Exchange) GetDepositStatuses(skyAddr string) ([]DepositStatus, error) {
+	dis, err := e.store.GetDepositInfoOfSkyAddress(skyAddr)
 	if err != nil {
 		return []DepositStatus{}, err
 	}
@@ -636,8 +224,8 @@ func (s *Exchange) GetDepositStatuses(skyAddr string) ([]DepositStatus, error) {
 }
 
 // GetDepositStatusDetail returns deposit status details
-func (s *Exchange) GetDepositStatusDetail(flt DepositFilter) ([]DepositStatusDetail, error) {
-	dis, err := s.store.GetDepositInfoArray(flt)
+func (e *Exchange) GetDepositStatusDetail(flt DepositFilter) ([]DepositStatusDetail, error) {
+	dis, err := e.store.GetDepositInfoArray(flt)
 	if err != nil {
 		return nil, err
 	}
@@ -658,14 +246,14 @@ func (s *Exchange) GetDepositStatusDetail(flt DepositFilter) ([]DepositStatusDet
 }
 
 // GetBindNum returns the number of btc/eth address the given sky address binded
-func (s *Exchange) GetBindNum(skyAddr string) (int, error) {
-	addrs, err := s.store.GetSkyBindAddresses(skyAddr)
+func (e *Exchange) GetBindNum(skyAddr string) (int, error) {
+	addrs, err := e.store.GetSkyBindAddresses(skyAddr)
 	return len(addrs), err
 }
 
 // GetDepositStats returns deposit status
-func (s *Exchange) GetDepositStats() (*DepositStats, error) {
-	tbr, tss, err := s.store.GetDepositStats()
+func (e *Exchange) GetDepositStats() (*DepositStats, error) {
+	tbr, tss, err := e.store.GetDepositStats()
 	if err != nil {
 		return nil, err
 	}
@@ -677,19 +265,19 @@ func (s *Exchange) GetDepositStats() (*DepositStats, error) {
 }
 
 // Balance returns the number of coins left in the OTC wallet
-func (s *Exchange) Balance() (*cli.Balance, error) {
-	return s.sender.Balance()
-}
-
-func (s *Exchange) setStatus(err error) {
-	defer s.statusLock.Unlock()
-	s.statusLock.Lock()
-	s.status = err
+func (e *Exchange) Balance() (*cli.Balance, error) {
+	return e.Sender.Balance()
 }
 
 // Status returns the last return value of the processing state
-func (s *Exchange) Status() error {
-	defer s.statusLock.RUnlock()
-	s.statusLock.RLock()
-	return s.status
+func (e *Exchange) Status() error {
+	return e.Sender.Status()
+}
+
+// BindAddress binds deposit address with skycoin address, and
+// add the btc/eth address to scan service, when detect deposit coin
+// to the btc/eth address, will send specific skycoin to the binded
+// skycoin address
+func (e *Exchange) BindAddress(skyAddr, depositAddr, coinType string) error {
+	return e.Receiver.BindAddress(skyAddr, depositAddr, coinType, e.buyMethod)
 }

--- a/src/exchange/exchange_test.go
+++ b/src/exchange/exchange_test.go
@@ -187,13 +187,15 @@ func newTestExchange(t *testing.T, log *logrus.Logger, db *bolt.DB) *Exchange {
 
 	go testutil.CheckError(t, multiplexer.Multiplex)
 
-	e, err := NewExchange(log, store, multiplexer, newDummySender(), config.SkyExchanger{
+	cfg := config.SkyExchanger{
 		SkyBtcExchangeRate:      testSkyBtcRate,
 		SkyEthExchangeRate:      testSkyEthRate,
 		TxConfirmationCheckWait: time.Millisecond * 100,
 		Wallet:                  testWalletFile,
 		SendEnabled:             true,
-	})
+	}
+
+	e, err := NewDirectExchange(log, cfg, store, multiplexer, newDummySender())
 	require.NoError(t, err)
 	return e
 }
@@ -217,8 +219,9 @@ func setupExchange(t *testing.T, log *logrus.Logger) (*Exchange, func(), func())
 
 	return e, run, shutdown
 }
+
 func closeMultiplexer(e *Exchange) {
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).stop()
 	mp.GetScanner(scanner.CoinTypeETH).(*dummyScanner).stop()
 	mp.Shutdown()
@@ -245,13 +248,15 @@ func runExchangeMockStore(t *testing.T) (*Exchange, func(), *logrus_test.Hook) {
 
 	go testutil.CheckError(t, multiplexer.Multiplex)
 
-	e, err := NewExchange(log, store, multiplexer, newDummySender(), config.SkyExchanger{
+	cfg := config.SkyExchanger{
 		SkyBtcExchangeRate:      testSkyBtcRate,
 		SkyEthExchangeRate:      testSkyEthRate,
 		TxConfirmationCheckWait: time.Millisecond * 100,
 		Wallet:                  testWalletFile,
 		SendEnabled:             true,
-	})
+	}
+
+	e, err := NewDirectExchange(log, cfg, store, multiplexer, newDummySender())
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -321,13 +326,13 @@ func TestExchangeRunSend(t *testing.T) {
 
 	skyAddr := testSkyAddr
 	btcAddr := "foo-btc-addr"
-	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC)
+	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC, BuyMethodDirect)
 	require.NoError(t, err)
 
 	var value int64 = 1e8
 	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
-	txid := e.sender.(*dummySender).predictTxid(t, skyAddr, skySent)
+	txid := e.Sender.(*Send).sender.(*dummySender).predictTxid(t, skyAddr, skySent)
 
 	dn := scanner.DepositNote{
 		Deposit: scanner.Deposit{
@@ -340,7 +345,7 @@ func TestExchangeRunSend(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// First loop calls saveIncomingDeposit
@@ -388,6 +393,7 @@ func TestExchangeRunSend(t *testing.T) {
 		DepositID:      dn.Deposit.ID(),
 		Txid:           txid,
 		SkySent:        100e6,
+		BuyMethod:      BuyMethodDirect,
 		ConversionRate: testSkyBtcRate,
 		DepositValue:   dn.Deposit.Value,
 		Deposit:        dn.Deposit,
@@ -396,7 +402,7 @@ func TestExchangeRunSend(t *testing.T) {
 	require.Equal(t, expectedDeposit, di)
 
 	// Mark the deposit as confirmed
-	e.sender.(*dummySender).setTxConfirmed(txid)
+	e.Sender.(*Send).sender.(*dummySender).setTxConfirmed(txid)
 
 	// Periodically check the database until we observe the confirmed deposit
 	done = make(chan struct{})
@@ -436,6 +442,7 @@ func TestExchangeRunSend(t *testing.T) {
 		DepositID:      dn.Deposit.ID(),
 		Txid:           txid,
 		SkySent:        100e6,
+		BuyMethod:      BuyMethodDirect,
 		ConversionRate: testSkyBtcRate,
 		DepositValue:   dn.Deposit.Value,
 		Deposit:        dn.Deposit,
@@ -457,12 +464,12 @@ func TestExchangeUpdateBroadcastTxFailure(t *testing.T) {
 
 	skyAddr := testSkyAddr
 	btcAddr := "foo-btc-addr"
-	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC)
+	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC, BuyMethodDirect)
 	require.NoError(t, err)
 
 	// Force sender to return a broadcast tx error so that the deposit stays at StatusWaitSend
 	broadcastTransactionErr := errors.New("fake broadcast transaction error")
-	e.sender.(*dummySender).broadcastTransactionErr = broadcastTransactionErr
+	e.Sender.(*Send).sender.(*dummySender).broadcastTransactionErr = broadcastTransactionErr
 
 	dn := scanner.DepositNote{
 		Deposit: scanner.Deposit{
@@ -475,7 +482,7 @@ func TestExchangeUpdateBroadcastTxFailure(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// First loop calls saveIncomingDeposit
@@ -499,6 +506,7 @@ func TestExchangeUpdateBroadcastTxFailure(t *testing.T) {
 		DepositAddress: btcAddr,
 		DepositID:      dn.Deposit.ID(),
 		Status:         StatusWaitSend,
+		BuyMethod:      BuyMethodDirect,
 		ConversionRate: testSkyBtcRate,
 		DepositValue:   dn.Deposit.Value,
 		Deposit:        dn.Deposit,
@@ -516,12 +524,12 @@ func TestExchangeCreateTxFailure(t *testing.T) {
 
 	skyAddr := testSkyAddr
 	btcAddr := "foo-btc-addr"
-	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC)
+	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC, BuyMethodDirect)
 	require.NoError(t, err)
 
 	// Force sender to return a create tx error so that the deposit stays at StatusWaitSend
 	createTransactionErr := errors.New("fake create transaction error")
-	e.sender.(*dummySender).createTransactionErr = createTransactionErr
+	e.Sender.(*Send).sender.(*dummySender).createTransactionErr = createTransactionErr
 
 	dn := scanner.DepositNote{
 		Deposit: scanner.Deposit{
@@ -534,7 +542,7 @@ func TestExchangeCreateTxFailure(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// First loop calls saveIncomingDeposit
@@ -558,6 +566,7 @@ func TestExchangeCreateTxFailure(t *testing.T) {
 		DepositID:      dn.Deposit.ID(),
 		Status:         StatusWaitSend,
 		ConversionRate: testSkyBtcRate,
+		BuyMethod:      BuyMethodDirect,
 		DepositValue:   dn.Deposit.Value,
 		Deposit:        dn.Deposit,
 	}, di)
@@ -572,17 +581,17 @@ func TestExchangeTxConfirmFailure(t *testing.T) {
 
 	skyAddr := testSkyAddr
 	btcAddr := "foo-btc-addr"
-	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC)
+	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC, BuyMethodDirect)
 	require.NoError(t, err)
 
 	var value int64 = 1e8
 	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
-	txid := e.sender.(*dummySender).predictTxid(t, skyAddr, skySent)
+	txid := e.Sender.(*Send).sender.(*dummySender).predictTxid(t, skyAddr, skySent)
 
 	// Force sender to return a confirm error so that the deposit stays at StatusWaitConfirm
 	confirmErr := errors.New("fake confirm error")
-	e.sender.(*dummySender).confirmErr = confirmErr
+	e.Sender.(*Send).sender.(*dummySender).confirmErr = confirmErr
 
 	dn := scanner.DepositNote{
 		Deposit: scanner.Deposit{
@@ -595,7 +604,7 @@ func TestExchangeTxConfirmFailure(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// First loop calls saveIncomingDeposit
@@ -640,6 +649,7 @@ func TestExchangeTxConfirmFailure(t *testing.T) {
 		Txid:           txid,
 		SkySent:        100e6,
 		DepositValue:   dn.Deposit.Value,
+		BuyMethod:      BuyMethodDirect,
 		Status:         StatusWaitConfirm,
 		ConversionRate: testSkyBtcRate,
 		Deposit:        dn.Deposit,
@@ -653,13 +663,13 @@ func TestExchangeQuitBeforeConfirm(t *testing.T) {
 
 	skyAddr := testSkyAddr
 	btcAddr := "foo-btc-addr"
-	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC)
+	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC, BuyMethodDirect)
 	require.NoError(t, err)
 
 	var value int64 = 1e8
 	skySent, err := CalculateBtcSkyValue(value, testSkyBtcRate, testMaxDecimals)
 	require.NoError(t, err)
-	txid := e.sender.(*dummySender).predictTxid(t, skyAddr, skySent)
+	txid := e.Sender.(*Send).sender.(*dummySender).predictTxid(t, skyAddr, skySent)
 
 	dn := scanner.DepositNote{
 		Deposit: scanner.Deposit{
@@ -672,7 +682,7 @@ func TestExchangeQuitBeforeConfirm(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// First loop calls saveIncomingDeposit
@@ -691,6 +701,7 @@ func TestExchangeQuitBeforeConfirm(t *testing.T) {
 		DepositID:      dn.Deposit.ID(),
 		Txid:           txid,
 		SkySent:        100e6,
+		BuyMethod:      BuyMethodDirect,
 		DepositValue:   dn.Deposit.Value,
 		ConversionRate: testSkyBtcRate,
 		Deposit:        dn.Deposit,
@@ -746,7 +757,7 @@ func TestExchangeSendZeroCoins(t *testing.T) {
 
 	skyAddr := testSkyAddr
 	btcAddr := "foo-btc-addr"
-	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC)
+	err := e.store.BindAddress(skyAddr, btcAddr, scanner.CoinTypeBTC, BuyMethodDirect)
 	require.NoError(t, err)
 
 	dn := scanner.DepositNote{
@@ -760,7 +771,7 @@ func TestExchangeSendZeroCoins(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// First loop calls saveIncomingDeposit
@@ -781,6 +792,7 @@ func TestExchangeSendZeroCoins(t *testing.T) {
 		Txid:           "",
 		SkySent:        0,
 		ConversionRate: testSkyBtcRate,
+		BuyMethod:      BuyMethodDirect,
 		DepositValue:   dn.Deposit.Value,
 		Deposit:        dn.Deposit,
 		Error:          ErrEmptySendAmount.Error(),
@@ -940,6 +952,7 @@ func TestExchangeProcessUnconfirmedTx(t *testing.T) {
 			Txid:           txid1,
 			SkySent:        skySent,
 			ConversionRate: testSkyBtcRate,
+			BuyMethod:      BuyMethodDirect,
 			DepositValue:   depositValue,
 			Deposit: scanner.Deposit{
 				CoinType: scanner.CoinTypeBTC,
@@ -959,6 +972,7 @@ func TestExchangeProcessUnconfirmedTx(t *testing.T) {
 			Txid:           txid2,
 			SkySent:        skySent,
 			ConversionRate: testSkyBtcRate,
+			BuyMethod:      BuyMethodDirect,
 			DepositValue:   depositValue,
 			Deposit: scanner.Deposit{
 				CoinType: scanner.CoinTypeBTC,
@@ -972,7 +986,7 @@ func TestExchangeProcessUnconfirmedTx(t *testing.T) {
 	}
 
 	testExchangeRunProcessDepositBacklog(t, dis, func(e *Exchange, di DepositInfo) {
-		e.sender.(*dummySender).setTxConfirmed(di.Txid)
+		e.Sender.(*Send).sender.(*dummySender).setTxConfirmed(di.Txid)
 	})
 }
 
@@ -1000,6 +1014,7 @@ func TestExchangeProcessWaitSendDeposits(t *testing.T) {
 			Txid:           txid1,
 			ConversionRate: testSkyBtcRate,
 			DepositValue:   depositValue,
+			BuyMethod:      BuyMethodDirect,
 			Deposit: scanner.Deposit{
 				CoinType: scanner.CoinTypeBTC,
 				Address:  "foo-btc-addr-1",
@@ -1019,6 +1034,7 @@ func TestExchangeProcessWaitSendDeposits(t *testing.T) {
 			Txid:           txid2,
 			ConversionRate: testSkyBtcRate,
 			DepositValue:   depositValue,
+			BuyMethod:      BuyMethodDirect,
 			Deposit: scanner.Deposit{
 				CoinType: scanner.CoinTypeBTC,
 				Address:  "foo-btc-addr-2",
@@ -1031,14 +1047,14 @@ func TestExchangeProcessWaitSendDeposits(t *testing.T) {
 	}
 
 	testExchangeRunProcessDepositBacklog(t, dis, func(e *Exchange, di DepositInfo) {
-		err := e.store.BindAddress(di.SkyAddress, di.DepositAddress, di.CoinType)
+		err := e.store.BindAddress(di.SkyAddress, di.DepositAddress, di.CoinType, di.BuyMethod)
 		require.NoError(t, err)
 
 		skySent, err := CalculateBtcSkyValue(di.DepositValue, di.ConversionRate, testMaxDecimals)
 		require.NoError(t, err)
 
-		txid := e.sender.(*dummySender).predictTxid(t, di.SkyAddress, skySent)
-		e.sender.(*dummySender).setTxConfirmed(txid)
+		txid := e.Sender.(*Send).sender.(*dummySender).predictTxid(t, di.SkyAddress, skySent)
+		e.Sender.(*Send).sender.(*dummySender).setTxConfirmed(txid)
 	})
 }
 
@@ -1066,7 +1082,7 @@ func TestExchangeSaveIncomingDepositCreateDepositFailed(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// Configure database mocks
@@ -1118,7 +1134,7 @@ func TestExchangeProcessWaitSendDepositFailed(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// Configure database mocks
@@ -1139,6 +1155,7 @@ func TestExchangeProcessWaitSendDepositFailed(t *testing.T) {
 		SkyAddress:     skyAddr,
 		DepositAddress: btcAddr,
 		DepositID:      dn.Deposit.ID(),
+		BuyMethod:      BuyMethodDirect,
 		ConversionRate: testSkyBtcRate,
 		Deposit:        dn.Deposit,
 	}
@@ -1210,7 +1227,7 @@ func TestExchangeProcessWaitSendNoSkyAddrBound(t *testing.T) {
 		},
 		ErrC: make(chan error, 1),
 	}
-	mp := e.multiplexer
+	mp := e.Receiver.(*Receive).multiplexer
 	mp.GetScanner(scanner.CoinTypeBTC).(*dummyScanner).addDeposit(dn)
 
 	// First loop calls saveIncomingDeposit
@@ -1227,6 +1244,13 @@ func TestExchangeProcessWaitSendNoSkyAddrBound(t *testing.T) {
 }
 
 func TestExchangeBindAddress(t *testing.T) {
+	cfg := config.SkyExchanger{
+		SkyBtcExchangeRate: "10",
+		SkyEthExchangeRate: "1",
+		Wallet:             testWalletFile,
+		SendEnabled:        true,
+	}
+
 	db, shutdown := testutil.PrepareDB(t)
 	defer shutdown()
 
@@ -1238,10 +1262,8 @@ func TestExchangeBindAddress(t *testing.T) {
 	err = multiplexer.AddScanner(dummyScanner, scanner.CoinTypeBTC)
 	require.NoError(t, err)
 
-	s := &Exchange{
-		store:       store,
-		multiplexer: multiplexer,
-	}
+	s, err := NewDirectExchange(log, cfg, store, multiplexer, nil)
+	require.NoError(t, err)
 
 	require.Len(t, dummyScanner.addrs, 0)
 
@@ -1267,7 +1289,7 @@ func TestExchangeCreateTransaction(t *testing.T) {
 	}
 
 	log, _ := testutil.NewLogger(t)
-	s, err := NewExchange(log, nil, nil, newDummySender(), cfg)
+	s, err := NewDirectExchange(log, cfg, nil, nil, newDummySender())
 	require.NoError(t, err)
 
 	// Create transaction with no SkyAddress
@@ -1278,7 +1300,7 @@ func TestExchangeCreateTransaction(t *testing.T) {
 		ConversionRate: "100",
 	}
 
-	_, err = s.createTransaction(di)
+	_, err = s.Sender.(*Send).createTransaction(di)
 	require.Equal(t, ErrNoBoundAddress, err)
 
 	// Create transaction with no coins sent, due to a very low DepositValue
@@ -1288,7 +1310,7 @@ func TestExchangeCreateTransaction(t *testing.T) {
 		DepositValue:   1,
 		ConversionRate: "100",
 	}
-	_, err = s.createTransaction(di)
+	_, err = s.Sender.(*Send).createTransaction(di)
 	require.Equal(t, ErrEmptySendAmount, err)
 
 	// Create valid transaction
@@ -1302,7 +1324,7 @@ func TestExchangeCreateTransaction(t *testing.T) {
 	// that the DepositInfo's ConversionRate is used instead of cfg.SkyBtcExchangeRate
 	require.NotEqual(t, s.cfg.SkyBtcExchangeRate, di.ConversionRate)
 
-	tx, err := s.createTransaction(di)
+	tx, err := s.Sender.(*Send).createTransaction(di)
 	require.NoError(t, err)
 	// Should have one output for destination and one for change
 	require.Len(t, tx.Out, 2)
@@ -1320,6 +1342,13 @@ func TestExchangeCreateTransaction(t *testing.T) {
 }
 
 func TestExchangeGetDepositStatuses(t *testing.T) {
+	cfg := config.SkyExchanger{
+		SkyBtcExchangeRate: "10",
+		SkyEthExchangeRate: "1",
+		Wallet:             testWalletFile,
+		SendEnabled:        true,
+	}
+
 	db, shutdown := testutil.PrepareDB(t)
 	defer shutdown()
 
@@ -1334,10 +1363,8 @@ func TestExchangeGetDepositStatuses(t *testing.T) {
 	err = multiplexer.AddScanner(dummyScannerEth, scanner.CoinTypeETH)
 	require.NoError(t, err)
 
-	s := &Exchange{
-		store:       store,
-		multiplexer: multiplexer,
-	}
+	s, err := NewDirectExchange(log, cfg, store, multiplexer, nil)
+	require.NoError(t, err)
 
 	require.Len(t, dummyScanner.addrs, 0)
 
@@ -1374,6 +1401,13 @@ func TestExchangeGetDepositStatusDetail(t *testing.T) {
 }
 
 func TestExchangeGetBindNum(t *testing.T) {
+	cfg := config.SkyExchanger{
+		SkyBtcExchangeRate: "10",
+		SkyEthExchangeRate: "1",
+		Wallet:             testWalletFile,
+		SendEnabled:        true,
+	}
+
 	db, shutdown := testutil.PrepareDB(t)
 	defer shutdown()
 
@@ -1385,16 +1419,15 @@ func TestExchangeGetBindNum(t *testing.T) {
 	multiplexer := scanner.NewMultiplexer(log)
 	err = multiplexer.AddScanner(bscr, scanner.CoinTypeBTC)
 	require.NoError(t, err)
-	s := &Exchange{
-		store:       store,
-		multiplexer: multiplexer,
-	}
+
+	s, err := NewDirectExchange(log, cfg, store, multiplexer, nil)
+	require.NoError(t, err)
 
 	num, err := s.GetBindNum("a")
 	require.Equal(t, num, 0)
 	require.NoError(t, err)
 
-	err = s.store.BindAddress("a", "b", scanner.CoinTypeBTC)
+	err = s.store.BindAddress("a", "b", scanner.CoinTypeBTC, BuyMethodDirect)
 	require.NoError(t, err)
 
 	num, err = s.GetBindNum("a")

--- a/src/exchange/receiver.go
+++ b/src/exchange/receiver.go
@@ -1,0 +1,221 @@
+package exchange
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/teller/src/config"
+	"github.com/skycoin/teller/src/scanner"
+)
+
+func init() {
+	// Assert that getRate() handles all coin types
+	cfg := config.SkyExchanger{
+		SkyBtcExchangeRate: "1",
+		SkyEthExchangeRate: "2",
+	}
+	for _, ct := range scanner.GetCoinTypes() {
+		rate, err := getRate(cfg, ct)
+		if err != nil {
+			panic(err)
+		}
+		if rate == "" {
+			panic(fmt.Sprintf("getRate(%s) did not find a rate", ct))
+		}
+	}
+}
+
+// Receiver is a component that reads deposits from a scanner.Scanner and records them
+type Receiver interface {
+	Deposits() <-chan DepositInfo
+	BindAddress(skyAddr, depositAddr, coinType, buyMethod string) error
+}
+
+// ReceiveRunner is a Receiver than can be run
+type ReceiveRunner interface {
+	Runner
+	Receiver
+}
+
+// Receive implements a Receiver. All incoming deposits are saved,
+// with the configured rate recorded at instantiation time [TODO: move that functionality to Processor?]
+type Receive struct {
+	log         logrus.FieldLogger
+	cfg         config.SkyExchanger
+	multiplexer *scanner.Multiplexer
+	store       Storer
+	deposits    chan DepositInfo
+	quit        chan struct{}
+	done        chan struct{}
+}
+
+// NewReceive creates a Receive
+func NewReceive(log logrus.FieldLogger, cfg config.SkyExchanger, store Storer, multiplexer *scanner.Multiplexer) (*Receive, error) {
+	// TODO -- split up config into relevant parts?
+	// The Receive component needs exchange rates
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &Receive{
+		log:         log.WithField("prefix", "teller.exchange.Receive"),
+		cfg:         cfg,
+		store:       store,
+		multiplexer: multiplexer,
+		deposits:    make(chan DepositInfo, 100),
+		quit:        make(chan struct{}),
+		done:        make(chan struct{}),
+	}, nil
+}
+
+// Run processes deposits from the scanner.Scanner, recording them and exposing them over the Deposits() channel
+func (r *Receive) Run() error {
+	log := r.log
+	log.Info("Start receive service...")
+	defer func() {
+		log.Info("Closed receive service")
+		r.done <- struct{}{}
+	}()
+
+	// Load StatusWaitDecide deposits for resubmission
+	waitDecideDeposits, err := r.store.GetDepositInfoArray(func(di DepositInfo) bool {
+		return di.Status == StatusWaitDecide
+	})
+
+	if err != nil {
+		err = fmt.Errorf("GetDepositInfoArray failed: %v", err)
+		log.WithError(err).Error(err)
+		return err
+	}
+
+	// Queue the saved StatusWaitDecide deposits
+	// This will block if there are too many waiting deposits, make sure that
+	// the Processor is running to receive them
+	for _, di := range waitDecideDeposits {
+		r.deposits <- di
+	}
+
+	var wg sync.WaitGroup
+
+	// This loop processes incoming deposits from the scanner and saves a
+	// new DepositInfo with a status of StatusWaitSend
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.runReadMultiplexer()
+	}()
+
+	wg.Wait()
+
+	return nil
+}
+
+// runReadMultiplexer reads deposits from the multiplexer
+func (r *Receive) runReadMultiplexer() {
+	log := r.log.WithField("goroutine", "readMultiplexer")
+	for {
+		var dv scanner.DepositNote
+		var ok bool
+		select {
+		case <-r.quit:
+			log.Info("quit")
+			return
+		case dv, ok = <-r.multiplexer.GetDeposit():
+			if !ok {
+				log.Warn("Scan service closed, watch deposits loop quit")
+				return
+			}
+
+		}
+		log := log.WithField("deposit", dv.Deposit)
+
+		// Save a new DepositInfo based upon the scanner.Deposit.
+		// If the save fails, report it to the scanner.
+		// The scanner will mark the deposit as "processed" if no error
+		// occurred.  Any unprocessed deposits held by the scanner
+		// will be resent to the exchange when teller is started.
+		if d, err := r.saveIncomingDeposit(dv.Deposit); err != nil {
+			log.WithError(err).Error("saveIncomingDeposit failed. This deposit will not be reprocessed until teller is restarted.")
+			dv.ErrC <- err
+		} else {
+			dv.ErrC <- nil
+			r.deposits <- d
+		}
+	}
+}
+
+// Shutdown stops a previous call to run
+func (r *Receive) Shutdown() {
+	r.log.Info("Shutting down Receive")
+	close(r.quit)
+	r.log.Info("Waiting for run to finish")
+	<-r.done
+	r.log.Info("Shutdown complete")
+}
+
+// Deposits returns a channel with recorded deposits
+func (r *Receive) Deposits() <-chan DepositInfo {
+	return r.deposits
+}
+
+// saveIncomingDeposit is called when receiving a deposit from the scanner
+func (r *Receive) saveIncomingDeposit(dv scanner.Deposit) (DepositInfo, error) {
+	log := r.log.WithField("deposit", dv)
+
+	var rate string
+	rate, err := r.getRate(dv.CoinType)
+	if err != nil {
+		log.WithError(err).Error("get conversion rate failed")
+		return DepositInfo{}, err
+	}
+
+	di, err := r.store.GetOrCreateDepositInfo(dv, rate)
+	if err != nil {
+		log.WithError(err).Error("GetOrCreateDepositInfo failed")
+		return DepositInfo{}, err
+	}
+
+	log = log.WithField("depositInfo", di)
+	log.Info("Saved DepositInfo")
+
+	return di, err
+}
+
+// getRate returns conversion rate according to coin type
+func (r *Receive) getRate(coinType string) (string, error) {
+	return getRate(r.cfg, coinType)
+}
+
+// getRate returns conversion rate according to coin type
+func getRate(cfg config.SkyExchanger, coinType string) (string, error) {
+	switch coinType {
+	case scanner.CoinTypeBTC:
+		return cfg.SkyBtcExchangeRate, nil
+	case scanner.CoinTypeETH:
+		return cfg.SkyEthExchangeRate, nil
+	default:
+		return "", scanner.ErrUnsupportedCoinType
+	}
+}
+
+// BindAddress binds deposit address with skycoin address, and
+// add the btc/eth address to scan service, when detect deposit coin
+// to the btc/eth address, will send specific skycoin to the binded
+// skycoin address
+func (r *Receive) BindAddress(skyAddr, depositAddr, coinType, buyMethod string) error {
+	if err := ValidateBuyMethod(buyMethod); err != nil {
+		return err
+	}
+
+	if err := r.multiplexer.ValidateCoinType(coinType); err != nil {
+		return err
+	}
+
+	if err := r.store.BindAddress(skyAddr, depositAddr, coinType, buyMethod); err != nil {
+		return err
+	}
+
+	return r.multiplexer.AddScanAddress(depositAddr, coinType)
+}

--- a/src/exchange/send.go
+++ b/src/exchange/send.go
@@ -1,0 +1,546 @@
+package exchange
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skycoin/src/api/cli"
+	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/util/droplet"
+
+	"github.com/skycoin/teller/src/config"
+	"github.com/skycoin/teller/src/scanner"
+	"github.com/skycoin/teller/src/sender"
+	"github.com/skycoin/teller/src/util/mathutil"
+)
+
+// Sender is a component for sending coins
+type Sender interface {
+	Status() error
+	Balance() (*cli.Balance, error)
+}
+
+// SendRunner a Sender than can be run
+type SendRunner interface {
+	Runner
+	Sender
+}
+
+// Send reads deposits from a Processor and sends coins
+type Send struct {
+	log         logrus.FieldLogger
+	cfg         config.SkyExchanger
+	processor   Processor
+	sender      sender.Sender // sender provides APIs for sending skycoin
+	store       Storer        // deposit info storage
+	quit        chan struct{}
+	done        chan struct{}
+	depositChan chan DepositInfo
+	statusLock  sync.RWMutex
+	status      error
+}
+
+// NewSend creates exchange service
+func NewSend(log logrus.FieldLogger, cfg config.SkyExchanger, store Storer, sender sender.Sender, processor Processor) (*Send, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	if cfg.TxConfirmationCheckWait == 0 {
+		cfg.TxConfirmationCheckWait = txConfirmationCheckWait
+	}
+
+	return &Send{
+		cfg:         cfg,
+		log:         log.WithField("prefix", "teller.exchange.send"),
+		processor:   processor,
+		sender:      sender,
+		store:       store,
+		quit:        make(chan struct{}),
+		done:        make(chan struct{}, 1),
+		depositChan: make(chan DepositInfo, 100),
+	}, nil
+}
+
+// Run starts the exchange process
+func (s *Send) Run() error {
+	log := s.log
+	log.Info("Start exchange service...")
+	defer func() {
+		log.Info("Closed exchange service")
+		s.done <- struct{}{}
+	}()
+
+	var wg sync.WaitGroup
+
+	if s.cfg.SendEnabled {
+		// Load StatusWaitSend deposits for processing later
+		waitSendDeposits, err := s.store.GetDepositInfoArray(func(di DepositInfo) bool {
+			return di.Status == StatusWaitSend
+		})
+
+		if err != nil {
+			err = fmt.Errorf("GetDepositInfoArray failed: %v", err)
+			log.WithError(err).Error(err)
+			return err
+		}
+
+		// Load StatusWaitConfirm deposits for processing later
+		waitConfirmDeposits, err := s.store.GetDepositInfoArray(func(di DepositInfo) bool {
+			return di.Status == StatusWaitConfirm
+		})
+
+		if err != nil {
+			err = fmt.Errorf("GetDepositInfoArray failed: %v", err)
+			log.WithError(err).Error(err)
+			return err
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.runSend()
+		}()
+
+		// Queue the saved StatusWaitConfirm deposits
+		for _, di := range waitConfirmDeposits {
+			s.depositChan <- di
+		}
+
+		// Queue the saved StatusWaitSend deposits
+		for _, di := range waitSendDeposits {
+			s.depositChan <- di
+		}
+	} else {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.runNoSend()
+		}()
+	}
+
+	// Merge processor.Deposits() into the internal depositChan
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.receiveDeposits()
+	}()
+
+	wg.Wait()
+
+	return nil
+}
+
+func (s *Send) runSend() {
+	// This loop processes StatusWaitSend deposits.
+	// Only one deposit is processed at a time; it will not send more coins
+	// until it receives confirmation of the previous send.
+	log := s.log.WithField("goroutine", "runSend")
+	for {
+		select {
+		case <-s.quit:
+			log.Info("quit")
+			return
+		case d := <-s.depositChan:
+			log := log.WithField("depositInfo", d)
+			if err := s.processWaitSendDeposit(d); err != nil {
+				log.WithError(err).Error("processWaitSendDeposit failed. This deposit will not be reprocessed until teller is restarted.")
+			}
+		}
+	}
+}
+
+func (s *Send) runNoSend() {
+	// Flush the deposit channel so that it doesn't fill up
+	log := s.log.WithField("goroutine", "runNoSend")
+	for {
+		select {
+		case <-s.quit:
+			log.Info("quit")
+			return
+		case d := <-s.depositChan:
+			log := log.WithField("depositInfo", d)
+			log.Warning("Received depositInfo, but sending is disabled")
+		}
+	}
+}
+
+func (s *Send) receiveDeposits() {
+	// Read deposits from the processor and place them on the internal deposit channel
+	// This is necessary as a separate step because deposits can come from other sources,
+	// specifically deposits that were partially in processing from a previous run will
+	// be loaded first, and not come from the receiver.
+	log := s.log.WithField("goroutine", "receiveDeposits")
+	for {
+		select {
+		case <-s.quit:
+			log.Info("quit")
+			return
+		case d := <-s.processor.Deposits():
+			log.WithField("depositInfo", d).Info("Received deposit from processor")
+			s.depositChan <- d
+		}
+	}
+}
+
+// Shutdown close the exchange service
+func (s *Send) Shutdown() {
+	close(s.quit)
+	s.log.Info("Waiting for Run() to finish")
+	<-s.done
+	s.log.Info("Shutdown complete")
+}
+
+// processDeposit advances a single deposit through three states:
+// StatusWaitSend -> StatusWaitConfirm
+// StatusWaitConfirm -> StatusDone
+// StatusWaitDeposit is never saved to the database, so it does not transition
+func (s *Send) processWaitSendDeposit(di DepositInfo) error {
+	log := s.log.WithField("depositInfo", di)
+	log.Info("Processing StatusWaitSend deposit")
+
+	for {
+		select {
+		case <-s.quit:
+			return nil
+		default:
+		}
+
+		log.Info("handleDepositInfoState")
+
+		var err error
+		di, err = s.handleDepositInfoState(di)
+		log = log.WithField("depositInfo", di)
+
+		s.setStatus(err)
+
+		switch err.(type) {
+		case sender.RPCError:
+			// Treat skycoin RPC/CLI errors as temporary.
+			// Some RPC/CLI errors are hypothetically permanent,
+			// but most likely it is an insufficient wallet balance or
+			// the skycoin node is unavailable.
+			// A permanent error suggests a bug in skycoin or teller so can be fixed.
+			log.WithError(err).Error("handleDepositInfoState failed")
+			select {
+			case <-time.After(s.cfg.TxConfirmationCheckWait):
+			case <-s.quit:
+				return nil
+			}
+		default:
+			switch err {
+			case nil:
+				break
+			case ErrNotConfirmed:
+				select {
+				case <-time.After(s.cfg.TxConfirmationCheckWait):
+				case <-s.quit:
+					return nil
+				}
+			default:
+				log.WithError(err).Error("handleDepositInfoState failed")
+				return err
+			}
+		}
+
+		if di.Status == StatusDone {
+			return nil
+		}
+	}
+}
+
+func (s *Send) handleDepositInfoState(di DepositInfo) (DepositInfo, error) {
+	log := s.log.WithField("deposit", di)
+
+	if err := di.ValidateForStatus(); err != nil {
+		log.WithError(err).Error("handleDepositInfoState's DepositInfo is invalid")
+		return di, err
+	}
+
+	switch di.Status {
+	case StatusWaitSend:
+		// Prepare skycoin transaction
+		skyTx, err := s.createTransaction(di)
+
+		if err != nil {
+			log.WithError(err).Error("createTransaction failed")
+
+			// If the send amount is empty, skip to StatusDone.
+			if err == ErrEmptySendAmount {
+				log.Info("Send amount is 0, skipping to StatusDone")
+				di, err = s.store.UpdateDepositInfo(di.DepositID, func(di DepositInfo) DepositInfo {
+					di.Status = StatusDone
+					di.Error = ErrEmptySendAmount.Error()
+					return di
+				})
+				if err != nil {
+					log.WithError(err).Error("Update DepositInfo set StatusDone failed")
+					return di, err
+				}
+
+				log.WithError(ErrEmptySendAmount).Info("DepositInfo set to StatusDone")
+
+				return di, nil
+			}
+
+			return di, err
+		}
+
+		// Find the coins from the skyTx
+		// The skyTx contains one output sent to the destination address,
+		// so this check is safe.
+		// It is verified earlier by verifyCreatedTransaction
+		var skySent uint64
+		for _, o := range skyTx.Out {
+			if o.Address.String() == di.SkyAddress {
+				skySent = o.Coins
+				break
+			}
+		}
+
+		if skySent == 0 {
+			err := errors.New("No output to destination address found in transaction")
+			log.WithError(err).Error(err)
+			return di, err
+		}
+
+		// Within a bolt.DB transaction, update the db then send the coins
+		// If the send fails, the data is rolled back
+		// If the db save fails, no coins had been sent
+		di, err = s.store.UpdateDepositInfoCallback(di.DepositID, func(di DepositInfo) DepositInfo {
+			di.Status = StatusWaitConfirm
+			di.Txid = skyTx.TxIDHex()
+			di.SkySent = skySent
+			return di
+		}, func(di DepositInfo) error {
+			// NOTE: broadcastTransaction retries indefinitely on error
+			// If the skycoin node is not reachable, this will block,
+			// which will also block the database since it's in a transaction
+			rsp, err := s.broadcastTransaction(skyTx)
+			if err != nil {
+				log.WithError(err).Error("broadcastTransaction failed")
+				return err
+			}
+
+			// Invariant assertion: do not return this as an error, since
+			// coins have been sent. This should never occur.
+			if rsp.Txid != skyTx.TxIDHex() {
+				log.Error("CRITICAL ERROR: BroadcastTxResponse.Txid != skyTx.TxIDHex()")
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			log.WithError(err).Error("store.UpdateDepositInfoCallback failed")
+			return di, err
+		}
+
+		log.Info("DepositInfo set to StatusWaitConfirm")
+
+		return di, nil
+
+	case StatusWaitConfirm:
+		// Wait for confirmation
+		rsp := s.sender.IsTxConfirmed(di.Txid)
+
+		if rsp == nil {
+			log.WithError(ErrNoResponse).Warn("Sender closed")
+			return di, ErrNoResponse
+		}
+
+		if rsp.Err != nil {
+			log.WithError(rsp.Err).Error("IsTxConfirmed failed")
+			return di, rsp.Err
+		}
+
+		if !rsp.Confirmed {
+			log.Info("Transaction is not confirmed yet")
+			return di, ErrNotConfirmed
+		}
+
+		log.Info("Transaction is confirmed")
+
+		di, err := s.store.UpdateDepositInfo(di.DepositID, func(di DepositInfo) DepositInfo {
+			di.Status = StatusDone
+			return di
+		})
+		if err != nil {
+			log.WithError(err).Error("UpdateDepositInfo set StatusDone failed")
+			return di, err
+		}
+
+		log.Info("DepositInfo status set to StatusDone")
+
+		return di, nil
+
+	case StatusDone:
+		log.Warn("DepositInfo already processed")
+		return di, nil
+
+	case StatusWaitDeposit:
+		// We don't save any deposits with StatusWaitDeposit.
+		// We can't transition to StatusWaitSend without a scanner.Deposit
+		log.Error("StatusWaitDeposit cannot be processed and should never be handled by this method")
+		fallthrough
+	case StatusUnknown:
+		fallthrough
+	default:
+		err := ErrDepositStatusInvalid
+		log.WithError(err).Error(err)
+		return di, err
+	}
+}
+
+func (s *Send) calculateSkyDroplets(di DepositInfo) (uint64, error) {
+	log := s.log
+	var err error
+	var skyAmt uint64
+	switch di.CoinType {
+	case scanner.CoinTypeBTC:
+		skyAmt, err = CalculateBtcSkyValue(di.DepositValue, di.ConversionRate, s.cfg.MaxDecimals)
+		if err != nil {
+			log.WithError(err).Error("CalculateBtcSkyValue failed")
+			return 0, err
+		}
+	case scanner.CoinTypeETH:
+		//Gwei convert to wei, because stored-value is Gwei in case overflow of uint64
+		skyAmt, err = CalculateEthSkyValue(mathutil.Gwei2Wei(di.DepositValue), di.ConversionRate, s.cfg.MaxDecimals)
+		if err != nil {
+			log.WithError(err).Error("CalculateEthSkyValue failed")
+			return 0, err
+		}
+	default:
+		log.WithError(scanner.ErrUnsupportedCoinType).Error()
+		return 0, scanner.ErrUnsupportedCoinType
+	}
+	return skyAmt, nil
+}
+
+func (s *Send) createTransaction(di DepositInfo) (*coin.Transaction, error) {
+	log := s.log.WithField("deposit", di)
+
+	// This should never occur, the DepositInfo is saved with a SkyAddress
+	// during GetOrCreateDepositInfo().
+	if di.SkyAddress == "" {
+		err := ErrNoBoundAddress
+		log.WithError(err).Error(err)
+		return nil, err
+	}
+
+	log = log.WithField("skyAddr", di.SkyAddress)
+	log = log.WithField("skyRate", di.ConversionRate)
+	log = log.WithField("maxDecimals", s.cfg.MaxDecimals)
+
+	skyAmt, err := s.calculateSkyDroplets(di)
+	if err != nil {
+		log.WithError(err).Error("calculateSkyDroplets failed")
+		return nil, err
+	}
+	skyAmtCoins, err := droplet.ToString(skyAmt)
+	if err != nil {
+		log.WithError(err).Error("droplet.ToString failed")
+		return nil, err
+	}
+
+	log = log.WithField("sendAmtDroplets", skyAmt)
+	log = log.WithField("sendAmtCoins", skyAmtCoins)
+
+	log.Info("Creating skycoin transaction")
+
+	if skyAmt == 0 {
+		err := ErrEmptySendAmount
+		log.WithError(err).Error(err)
+		return nil, err
+	}
+
+	tx, err := s.sender.CreateTransaction(di.SkyAddress, skyAmt)
+	if err != nil {
+		log.WithError(err).Error("sender.CreateTransaction failed")
+		return nil, err
+	}
+
+	log = log.WithField("transactionOutput", tx.Out)
+
+	if err := verifyCreatedTransaction(tx, di, skyAmt); err != nil {
+		log.WithError(err).Error("verifyCreatedTransaction failed")
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+func verifyCreatedTransaction(tx *coin.Transaction, di DepositInfo, skyAmt uint64) error {
+	// Check invariant assertions:
+	// The transaction should contain one output to the destination address.
+	// It may or may not have a change output.
+	count := 0
+
+	for _, o := range tx.Out {
+		if o.Address.String() != di.SkyAddress {
+			continue
+		}
+
+		count++
+
+		if o.Coins != skyAmt {
+			return errors.New("CreateTransaction transaction coins are different")
+		}
+	}
+
+	if count == 0 {
+		return fmt.Errorf("CreateTransaction transaction has no output to address %s", di.SkyAddress)
+	} else if count > 1 {
+		return fmt.Errorf("CreateTransaction transaction has multiple outputs to address %s", di.SkyAddress)
+	}
+
+	return nil
+}
+
+func (s *Send) broadcastTransaction(tx *coin.Transaction) (*sender.BroadcastTxResponse, error) {
+	log := s.log.WithField("txid", tx.TxIDHex())
+
+	log.Info("Broadcasting skycoin transaction")
+
+	rsp := s.sender.BroadcastTransaction(tx)
+
+	log = log.WithField("sendRsp", rsp)
+
+	if rsp == nil {
+		err := ErrNoResponse
+		log.WithError(err).Warn("Sender closed")
+		return nil, err
+	}
+
+	if rsp.Err != nil {
+		err := fmt.Errorf("Send skycoin failed: %v", rsp.Err)
+		log.WithError(err).Error(err)
+		return nil, err
+	}
+
+	log.Info("Sent skycoin")
+
+	return rsp, nil
+}
+
+// Balance returns the number of coins left in the OTC wallet
+func (s *Send) Balance() (*cli.Balance, error) {
+	return s.sender.Balance()
+}
+
+func (s *Send) setStatus(err error) {
+	defer s.statusLock.Unlock()
+	s.statusLock.Lock()
+	s.status = err
+}
+
+// Status returns the last return value of the processing state
+func (s *Send) Status() error {
+	defer s.statusLock.RUnlock()
+	s.statusLock.RLock()
+	return s.status
+}

--- a/src/exchange/store.go
+++ b/src/exchange/store.go
@@ -411,34 +411,6 @@ func (s *Store) GetDepositInfoArray(flt DepositFilter) ([]DepositInfo, error) {
 	return dpis, nil
 }
 
-// getDepositAddressCoinType returns coin type of deposit address
-// TODO -- remove? unused?
-func (s *Store) getDepositAddressCoinType(depositAddr string) (string, error) {
-	var coinType string
-	if err := s.db.View(func(tx *bolt.Tx) error {
-		for _, ct := range scanner.GetCoinTypes() {
-			bktFullName, err := GetBindAddressBkt(ct)
-			if err != nil {
-				return err
-			}
-
-			exists, err := dbutil.BucketHasKey(tx, bktFullName, depositAddr)
-			if err != nil {
-				return err
-			}
-
-			if exists {
-				coinType = ct
-				break
-			}
-		}
-		return nil
-	}); err != nil {
-		return "", err
-	}
-	return coinType, nil
-}
-
 // GetDepositInfoOfSkyAddress returns all deposit info that are bound
 // to the given skycoin address
 func (s *Store) GetDepositInfoOfSkyAddress(skyAddr string) ([]DepositInfo, error) {

--- a/src/scanner/store_test.go
+++ b/src/scanner/store_test.go
@@ -33,7 +33,7 @@ func TestNewStore(t *testing.T) {
 	require.NoError(t, err)
 
 	err = s.db.View(func(tx *bolt.Tx) error {
-		scanBktFullName := dbutil.ByteJoin(scanMetaBktPrefix, CoinTypeBTC, "_")
+		scanBktFullName := MustGetScanMetaBkt(CoinTypeBTC)
 		bkt := tx.Bucket(scanBktFullName)
 		require.NotNil(t, bkt)
 
@@ -77,7 +77,7 @@ func TestGetDepositAddresses(t *testing.T) {
 	// check db
 	err = s.db.View(func(tx *bolt.Tx) error {
 		var as []string
-		scanBktFullName := dbutil.ByteJoin(scanMetaBktPrefix, CoinTypeBTC, "_")
+		scanBktFullName := MustGetScanMetaBkt(CoinTypeBTC)
 		err := dbutil.GetBucketObject(tx, scanBktFullName, depositAddressesKey, &as)
 		require.NoError(t, err)
 
@@ -135,7 +135,7 @@ func TestAddDepositAddress(t *testing.T) {
 			require.NoError(t, err)
 
 			err = db.Update(func(tx *bolt.Tx) error {
-				scanBktFullName := dbutil.ByteJoin(scanMetaBktPrefix, CoinTypeBTC, "_")
+				scanBktFullName := MustGetScanMetaBkt(CoinTypeBTC)
 				return dbutil.PutBucketValue(tx, scanBktFullName, depositAddressesKey, tc.initAddrs)
 			})
 			require.NoError(t, err)

--- a/src/teller/http.go
+++ b/src/teller/http.go
@@ -335,6 +335,7 @@ func (s *HTTPServer) Shutdown() {
 type BindResponse struct {
 	DepositAddress string `json:"deposit_address,omitempty"`
 	CoinType       string `json:"coin_type,omitempty"`
+	BuyMethod      string `json:"buy_method"`
 }
 
 type bindRequest struct {
@@ -415,7 +416,7 @@ func BindHandler(s *HTTPServer) http.HandlerFunc {
 
 		log.Info("Calling service.BindAddress")
 
-		coinAddr, err := s.service.BindAddress(bindReq.SkyAddr, bindReq.CoinType)
+		boundAddr, err := s.service.BindAddress(bindReq.SkyAddr, bindReq.CoinType)
 		if err != nil {
 			log.WithError(err).Error("service.BindAddress failed")
 			switch err {
@@ -432,12 +433,13 @@ func BindHandler(s *HTTPServer) http.HandlerFunc {
 			return
 		}
 
-		log = log.WithField("coinAddr", coinAddr)
+		log = log.WithField("boundAddr", boundAddr)
 		log.Infof("Bound sky and %s addresses", bindReq.CoinType)
 
 		if err := httputil.JSONResponse(w, BindResponse{
-			DepositAddress: coinAddr,
-			CoinType:       bindReq.CoinType,
+			DepositAddress: boundAddr.Address,
+			CoinType:       boundAddr.CoinType,
+			BuyMethod:      boundAddr.BuyMethod,
 		}); err != nil {
 			log.WithError(err).Error(err)
 		}

--- a/src/teller/http_test.go
+++ b/src/teller/http_test.go
@@ -24,7 +24,13 @@ type fakeExchanger struct {
 
 func (e *fakeExchanger) BindAddress(skyAddr, depositAddr, coinType string) error {
 	args := e.Called(skyAddr, depositAddr, coinType)
-	return args.Error(0)
+
+	ba := args.Get(0)
+	if ba == nil {
+		return nil, args.Error(1)
+	}
+
+	return ba.(*BoundAddress), args.Error(1)
 }
 
 func (e *fakeExchanger) GetDepositStatuses(skyAddr string) ([]exchange.DepositStatus, error) {

--- a/src/teller/http_test.go
+++ b/src/teller/http_test.go
@@ -22,7 +22,7 @@ type fakeExchanger struct {
 	mock.Mock
 }
 
-func (e *fakeExchanger) BindAddress(skyAddr, depositAddr, coinType string) error {
+func (e *fakeExchanger) BindAddress(skyAddr, depositAddr, coinType string) (*exchange.BoundAddress, error) {
 	args := e.Called(skyAddr, depositAddr, coinType)
 
 	ba := args.Get(0)
@@ -30,7 +30,7 @@ func (e *fakeExchanger) BindAddress(skyAddr, depositAddr, coinType string) error
 		return nil, args.Error(1)
 	}
 
-	return ba.(*BoundAddress), args.Error(1)
+	return ba.(*exchange.BoundAddress), args.Error(1)
 }
 
 func (e *fakeExchanger) GetDepositStatuses(skyAddr string) ([]exchange.DepositStatus, error) {

--- a/src/teller/teller.go
+++ b/src/teller/teller.go
@@ -80,32 +80,28 @@ type Service struct {
 
 // BindAddress binds skycoin address with a deposit address according to coinType
 // return deposit address
-func (s *Service) BindAddress(skyAddr, coinType string) (string, error) {
+func (s *Service) BindAddress(skyAddr, coinType string) (*exchange.BoundAddress, error) {
 	if !s.cfg.BindEnabled {
-		return "", ErrBindDisabled
+		return nil, ErrBindDisabled
 	}
 
 	if s.cfg.MaxBoundAddresses > 0 {
 		num, err := s.exchanger.GetBindNum(skyAddr)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		if num >= s.cfg.MaxBoundAddresses {
-			return "", ErrMaxBoundAddresses
+			return nil, ErrMaxBoundAddresses
 		}
 	}
 
 	depositAddr, err := s.addrManager.NewAddress(coinType)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	if err := s.exchanger.BindAddress(skyAddr, depositAddr, coinType); err != nil {
-		return "", err
-	}
-
-	return depositAddr, nil
+	return s.exchanger.BindAddress(skyAddr, depositAddr, coinType)
 }
 
 // GetDepositStatuses returns deposit status of given skycoin address

--- a/src/util/dbutil/dbutil.go
+++ b/src/util/dbutil/dbutil.go
@@ -1,7 +1,6 @@
 package dbutil
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -154,9 +153,4 @@ func ForEach(tx *bolt.Tx, bktName []byte, f func(k, v []byte) error) error {
 	}
 
 	return bkt.ForEach(f)
-}
-
-//ByteJoin Join byte array and string with seq, return byte array
-func ByteJoin(tupledata []byte, suffix, sep string) []byte {
-	return bytes.Join([][]byte{tupledata, []byte(suffix)}, []byte(sep))
 }


### PR DESCRIPTION
`exchange.Exchange` is broken down into 3 components:

* `Receiver` - reads deposits from a `scanner.Multiplexer` and saves them
* `Processor` - performs an action based upon a received deposit
* `Sender` - sends coins after processing

`Processor` will be customizable. `DirectBuy` implements the current processing mode: immediately go to send (essentially a no-op).  OTC passthrough will be implemented as a processor.

Updates the bound address API to attach metadata to the bound address.

TODO -- Needs database migration