### PR TITLE
Fix race condition errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ test: ## Run tests
 	go test ./cmd/... -timeout=1m -cover
 	go test ./src/... -timeout=1m -cover
 
+test-race: ## Run tests with -race. Note: expected to fail, but look for "DATA RACE" failures specifically
+	go test ./src/... -timeout=2m -race
+
 lint: ## Run linters. Use make install-linters first.
 	vendorcheck ./...
 	gometalinter --deadline=3m -j 2 --disable-all --tests --vendor \

--- a/src/sender/sky_test.go
+++ b/src/sender/sky_test.go
@@ -31,10 +31,15 @@ func newDummySkyClient() *dummySkyClient {
 }
 
 func (ds *dummySkyClient) BroadcastTransaction(tx *coin.Transaction) (string, error) {
+	ds.Lock()
+	defer ds.Unlock()
 	return ds.broadcastTxTxid, ds.broadcastTxErr
 }
 
 func (ds *dummySkyClient) CreateTransaction(destAddr string, coins uint64) (*coin.Transaction, error) {
+	ds.Lock()
+	defer ds.Unlock()
+
 	if ds.createTxErr != nil {
 		return nil, ds.createTxErr
 	}


### PR DESCRIPTION
Fix #228 

There is still one race condition between a goroutine used inside of a test to scan a mock log hook for a log entry in order to detect when to stop the test.  This does not have an impact on the production code and is benign.