### PR TITLE
add /api/backup in monitor to backup boltdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
     - [Deposits By Status](#deposits-by-status)
     - [Deposit Errors](#deposit-errors)
     - [Accounting](#accounting)
+    - [Backup](#backup)
 - [Code linting](#code-linting)
 - [Run tests](#run-tests)
 - [Database structure](#database-structure)
@@ -894,6 +895,20 @@ Response:
     }
 }
 ```
+
+### Backup
+```sh
+Method: GET
+URI: /api/backup
+```
+
+Starts a backup download
+
+Example:
+```sh
+curl -o teller-$(date +%s).db http://localhost:7711/api/backup
+```
+
 
 ## Code linting
 

--- a/cmd/teller/teller.go
+++ b/cmd/teller/teller.go
@@ -407,14 +407,12 @@ func run() error {
 			return err
 		}
 	}
-	tellerServer := teller.New(log, exchangeClient, addrManager, cfg)
+	tellerServer := teller.New(log, exchangeClient, addrManager, cfg, db)
 
 	// Run the service
 	background("tellerServer.Run", errC, tellerServer.Run)
-
 	// Start monitor service
-	monitorService := monitor.New(log, cfg, addrManager, exchangeClient, scanStore)
-
+	monitorService := monitor.New(log, cfg, addrManager, exchangeClient, scanStore, tellerServer)
 	background("monitorService.Run", errC, monitorService.Run)
 
 	var finalErr error

--- a/cmd/teller/teller.go
+++ b/cmd/teller/teller.go
@@ -407,12 +407,12 @@ func run() error {
 			return err
 		}
 	}
-	tellerServer := teller.New(log, exchangeClient, addrManager, cfg, db)
+	tellerServer := teller.New(log, exchangeClient, addrManager, cfg)
 
 	// Run the service
 	background("tellerServer.Run", errC, tellerServer.Run)
 	// Start monitor service
-	monitorService := monitor.New(log, cfg, addrManager, exchangeClient, scanStore, tellerServer)
+	monitorService := monitor.New(log, cfg, addrManager, exchangeClient, scanStore, db)
 	background("monitorService.Run", errC, monitorService.Run)
 
 	var finalErr error

--- a/src/monitor/monitor.go
+++ b/src/monitor/monitor.go
@@ -40,6 +40,7 @@ type DepositStatusGetter interface {
 	ErroredDeposits() ([]exchange.DepositInfo, error)
 }
 
+// Backuper interface provides an API to access the backup func of teller
 type Backuper interface {
 	Backup() http.HandlerFunc
 }
@@ -58,7 +59,7 @@ type Monitor struct {
 	cfg                 config.Config
 	ln                  *http.Server
 	Backuper
-	quit                chan struct{}
+	quit chan struct{}
 }
 
 // New creates monitor service

--- a/src/monitor/monitor_test.go
+++ b/src/monitor/monitor_test.go
@@ -87,8 +87,15 @@ type dummyScanAddrs struct {
 	// addrs []string
 }
 
-func (ds dummyScanAddrs) GetScanAddresses(coinType string) ([]string, error) {
+func (ds dummyScanAddrs) GetScanAddresses(string) ([]string, error) {
 	return []string{}, nil
+}
+
+type dummyBackuper struct {
+}
+
+func (bkper *dummyBackuper) Backup() http.HandlerFunc {
+	return nil
 }
 
 func TestRunMonitor(t *testing.T) {
@@ -139,7 +146,7 @@ func TestRunMonitor(t *testing.T) {
 	err = addrMgr.PushGenerator(&dummySkyAddrMgr{12}, config.CoinTypeSKY)
 	require.NoError(t, err)
 
-	m := New(log, cfg, addrMgr, &dummyDps, &dummyScanAddrs{})
+	m := New(log, cfg, addrMgr, &dummyDps, &dummyScanAddrs{}, &dummyBackuper{})
 
 	done := make(chan struct{})
 	go func() {

--- a/src/monitor/monitor_test.go
+++ b/src/monitor/monitor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/skycoin/teller/src/config"
 	"github.com/skycoin/teller/src/exchange"
 	"github.com/skycoin/teller/src/util/testutil"
+	"github.com/boltdb/bolt"
 )
 
 type dummyBtcAddrMgr struct {
@@ -91,13 +92,6 @@ func (ds dummyScanAddrs) GetScanAddresses(string) ([]string, error) {
 	return []string{}, nil
 }
 
-type dummyBackuper struct {
-}
-
-func (bkper *dummyBackuper) Backup() http.HandlerFunc {
-	return nil
-}
-
 func TestRunMonitor(t *testing.T) {
 	dpis := []exchange.DepositInfo{
 		{
@@ -146,7 +140,7 @@ func TestRunMonitor(t *testing.T) {
 	err = addrMgr.PushGenerator(&dummySkyAddrMgr{12}, config.CoinTypeSKY)
 	require.NoError(t, err)
 
-	m := New(log, cfg, addrMgr, &dummyDps, &dummyScanAddrs{}, &dummyBackuper{})
+	m := New(log, cfg, addrMgr, &dummyDps, &dummyScanAddrs{}, &bolt.DB{})
 
 	done := make(chan struct{})
 	go func() {

--- a/src/scanner/btc.go
+++ b/src/scanner/btc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/sirupsen/logrus"
+
 	"github.com/skycoin/teller/src/config"
 )
 

--- a/src/scanner/sky.go
+++ b/src/scanner/sky.go
@@ -8,6 +8,7 @@ import (
 	"github.com/skycoin/skycoin/src/gui"
 	"github.com/skycoin/skycoin/src/util/droplet"
 	"github.com/skycoin/skycoin/src/visor"
+
 	"github.com/skycoin/teller/src/config"
 )
 

--- a/src/teller/teller.go
+++ b/src/teller/teller.go
@@ -13,6 +13,8 @@ import (
 	"github.com/skycoin/teller/src/addrs"
 	"github.com/skycoin/teller/src/config"
 	"github.com/skycoin/teller/src/exchange"
+	"strings"
+	"time"
 )
 
 var (
@@ -82,12 +84,14 @@ func (s *Teller) Backup() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := s.db.View(func(tx *bolt.Tx) error {
 			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Header().Set("Content-Disposition", `attachment; filename="teller.db"`)
+			w.Header().Set("Content-Disposition", `attachment; ` +
+			"teller-"+ strconv.Itoa(int(time.Now().Unix())) + ".db" )
 			w.Header().Set("Content-Length", strconv.Itoa(int(tx.Size())))
 			_, err := tx.WriteTo(w)
 			return err
 		})
 		if err != nil {
+			s.log.Errorf("Backup failed: %v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}

--- a/src/teller/teller.go
+++ b/src/teller/teller.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/boltdb/bolt"
 
+	"fmt"
+	"time"
+
 	"github.com/skycoin/teller/src/addrs"
 	"github.com/skycoin/teller/src/config"
 	"github.com/skycoin/teller/src/exchange"
-	"strings"
-	"time"
 )
 
 var (
@@ -80,12 +81,13 @@ func (s *Teller) Shutdown() {
 	<-s.done
 }
 
+// Backup starts a timestamped backup download
 func (s *Teller) Backup() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := s.db.View(func(tx *bolt.Tx) error {
 			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Header().Set("Content-Disposition", `attachment; ` +
-			"teller-"+ strconv.Itoa(int(time.Now().Unix())) + ".db" )
+			w.Header().Set("Content-Disposition",
+				fmt.Sprintf(`attachment; filename="%s"`, "teller-"+strconv.Itoa(int(time.Now().Unix()))+".db"))
 			w.Header().Set("Content-Length", strconv.Itoa(int(tx.Size())))
 			_, err := tx.WriteTo(w)
 			return err


### PR DESCRIPTION
--- Old ---
- exposed `db` to teller 
- create a `Backup` function in teller which returns `http.Handlerfunc` to start backup download
- created a `Backuper` interface in `monitor` to expose the `Backup` function from `teller` to `monitor`

--- Edit ---
- expose `db` to monitor 
- create a `Backup` function in monitor which returns `http.Handlerfunc` to start backup download
